### PR TITLE
Add React frontend scaffold with Auth0 integration

### DIFF
--- a/frontend-web/.gitignore
+++ b/frontend-web/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env

--- a/frontend-web/index.html
+++ b/frontend-web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MedFinance Frontend</title>
+  </head>
+  <body class="bg-slate-100 text-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend-web/package.json
+++ b/frontend-web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "frontend-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@auth0/auth0-react": "^2.1.2",
+    "axios": "^1.6.7",
+    "d3": "^7.8.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.0.8"
+  }
+}

--- a/frontend-web/postcss.config.js
+++ b/frontend-web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend-web/src/App.jsx
+++ b/frontend-web/src/App.jsx
@@ -1,0 +1,22 @@
+import { Route, Routes } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import LoginPage from './pages/LoginPage';
+import DashboardPage from './pages/DashboardPage';
+import AdminPage from './pages/AdminPage';
+
+const App = () => {
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <main className="mx-auto max-w-6xl px-4 py-8">
+        <Routes>
+          <Route path="/" element={<LoginPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/admin" element={<AdminPage />} />
+        </Routes>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend-web/src/components/Navbar.jsx
+++ b/frontend-web/src/components/Navbar.jsx
@@ -1,0 +1,52 @@
+import { NavLink } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+
+const linkClasses = ({ isActive }) =>
+  `px-3 py-2 rounded-md text-sm font-medium transition-colors duration-150 ${
+    isActive ? 'bg-blue-600 text-white' : 'text-slate-200 hover:bg-blue-500 hover:text-white'
+  }`;
+
+const Navbar = () => {
+  const { isAuthenticated, loginWithRedirect, logout, user } = useAuth0();
+
+  return (
+    <nav className="bg-blue-700 text-white shadow">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <div className="text-lg font-semibold">MedFinance</div>
+        <div className="flex items-center gap-4">
+          <NavLink to="/" className={linkClasses} end>
+            Login
+          </NavLink>
+          <NavLink to="/dashboard" className={linkClasses}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/admin" className={linkClasses}>
+            Admin
+          </NavLink>
+        </div>
+        <div className="flex items-center gap-3">
+          {isAuthenticated && (
+            <span className="text-sm text-slate-200">{user?.name}</span>
+          )}
+          {isAuthenticated ? (
+            <button
+              onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+              className="rounded bg-white px-3 py-2 text-sm font-medium text-blue-700 shadow hover:bg-slate-100"
+            >
+              Logout
+            </button>
+          ) : (
+            <button
+              onClick={() => loginWithRedirect()}
+              className="rounded bg-white px-3 py-2 text-sm font-medium text-blue-700 shadow hover:bg-slate-100"
+            >
+              Login
+            </button>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/frontend-web/src/index.css
+++ b/frontend-web/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-100 text-slate-900;
+}

--- a/frontend-web/src/main.jsx
+++ b/frontend-web/src/main.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
+import './index.css';
+
+const domain = import.meta.env.VITE_AUTH0_DOMAIN || '';
+const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID || '';
+const redirectUri = window.location.origin;
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Auth0Provider
+      domain={domain}
+      clientId={clientId}
+      authorizationParams={{ redirect_uri: redirectUri }}
+    >
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Auth0Provider>
+  </React.StrictMode>
+);

--- a/frontend-web/src/pages/AdminPage.jsx
+++ b/frontend-web/src/pages/AdminPage.jsx
@@ -1,0 +1,45 @@
+import { useAuth0 } from '@auth0/auth0-react';
+
+const AdminPage = () => {
+  const { isAuthenticated, user, loginWithRedirect } = useAuth0();
+
+  if (!isAuthenticated) {
+    return (
+      <section className="rounded-lg bg-white p-8 shadow">
+        <h2 className="text-xl font-semibold text-slate-800">Área restrita</h2>
+        <p className="mt-4 text-slate-600">Você precisa estar autenticado para acessar o painel administrativo.</p>
+        <button
+          onClick={() => loginWithRedirect()}
+          className="mt-6 rounded bg-blue-600 px-4 py-2 font-medium text-white shadow hover:bg-blue-700"
+        >
+          Entrar com Auth0
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-lg bg-white p-8 shadow">
+      <h2 className="text-xl font-semibold text-slate-800">Administração</h2>
+      <p className="mt-4 text-slate-600">
+        Bem-vindo(a), {user?.name || user?.email}. Gerencie usuários, permissões e configurações do sistema.
+      </p>
+      <ul className="mt-6 space-y-3">
+        <li className="rounded border border-slate-200 p-4">
+          <h3 className="font-semibold text-slate-800">Gestão de Usuários</h3>
+          <p className="text-sm text-slate-600">Convide novos membros e defina papéis de acesso.</p>
+        </li>
+        <li className="rounded border border-slate-200 p-4">
+          <h3 className="font-semibold text-slate-800">Configurações de Segurança</h3>
+          <p className="text-sm text-slate-600">Atualize políticas de autenticação, MFA e auditoria.</p>
+        </li>
+        <li className="rounded border border-slate-200 p-4">
+          <h3 className="font-semibold text-slate-800">Relatórios</h3>
+          <p className="text-sm text-slate-600">Visualize relatórios financeiros avançados e exporte dados.</p>
+        </li>
+      </ul>
+    </section>
+  );
+};
+
+export default AdminPage;

--- a/frontend-web/src/pages/DashboardPage.jsx
+++ b/frontend-web/src/pages/DashboardPage.jsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import * as d3 from 'd3';
+import { healthcheck } from '../services/api';
+
+const DashboardPage = () => {
+  const { isAuthenticated, user, loginWithRedirect } = useAuth0();
+  const [status, setStatus] = useState({ loading: true, data: null, error: null });
+
+  useEffect(() => {
+    let active = true;
+    const fetchHealthcheck = async () => {
+      try {
+        const data = await healthcheck();
+        if (active) {
+          setStatus({ loading: false, data, error: null });
+        }
+      } catch (error) {
+        if (active) {
+          setStatus({ loading: false, data: null, error: error.message });
+        }
+      }
+    };
+
+    fetchHealthcheck();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const chartData = useMemo(
+    () =>
+      d3
+        .scaleLinear()
+        .domain([0, 4])
+        .ticks(5)
+        .map((value, index) => ({
+          label: `Q${index + 1}`,
+          value: d3.randomInt(10, 100)()
+        })),
+    []
+  );
+
+  if (!isAuthenticated) {
+    return (
+      <section className="rounded-lg bg-white p-8 shadow">
+        <h2 className="text-xl font-semibold text-slate-800">Autenticação necessária</h2>
+        <p className="mt-4 text-slate-600">
+          Faça login para visualizar o dashboard com os indicadores financeiros.
+        </p>
+        <button
+          onClick={() => loginWithRedirect()}
+          className="mt-6 rounded bg-blue-600 px-4 py-2 font-medium text-white shadow hover:bg-blue-700"
+        >
+          Entrar com Auth0
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-8">
+      <div className="rounded-lg bg-white p-8 shadow">
+        <h2 className="text-xl font-semibold text-slate-800">Dashboard</h2>
+        <p className="mt-2 text-slate-600">Olá, {user?.name || user?.email}! Aqui estão seus indicadores.</p>
+        <div className="mt-6">
+          {status.loading && <p className="text-sm text-slate-500">Carregando status do backend...</p>}
+          {status.error && (
+            <p className="text-sm text-red-600">Erro ao conectar: {status.error}</p>
+          )}
+          {status.data && (
+            <div className="rounded border border-green-200 bg-green-50 p-4 text-green-700">
+              <h3 className="font-medium">Status do backend</h3>
+              <pre className="mt-2 whitespace-pre-wrap text-sm">{JSON.stringify(status.data, null, 2)}</pre>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white p-8 shadow">
+        <h3 className="text-lg font-semibold text-slate-800">Indicadores trimestrais</h3>
+        <p className="mt-2 text-sm text-slate-600">Valores aleatórios gerados para demonstração.</p>
+        <div className="mt-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+          {chartData.map((item) => (
+            <div key={item.label} className="rounded bg-blue-100 p-4 text-center">
+              <p className="text-sm font-medium text-blue-700">{item.label}</p>
+              <p className="mt-2 text-2xl font-bold text-blue-900">{item.value}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default DashboardPage;

--- a/frontend-web/src/pages/LoginPage.jsx
+++ b/frontend-web/src/pages/LoginPage.jsx
@@ -1,0 +1,26 @@
+import { useAuth0 } from '@auth0/auth0-react';
+
+const LoginPage = () => {
+  const { loginWithRedirect, isAuthenticated, user } = useAuth0();
+
+  return (
+    <section className="rounded-lg bg-white p-8 shadow">
+      <h1 className="text-2xl font-semibold text-slate-800">Bem-vindo ao MedFinance</h1>
+      <p className="mt-4 text-slate-600">
+        {isAuthenticated
+          ? `Você está autenticado como ${user?.name || user?.email}.`
+          : 'Faça login para acessar o painel financeiro e os recursos administrativos.'}
+      </p>
+      {!isAuthenticated && (
+        <button
+          onClick={() => loginWithRedirect()}
+          className="mt-6 rounded bg-blue-600 px-4 py-2 font-medium text-white shadow hover:bg-blue-700"
+        >
+          Entrar com Auth0
+        </button>
+      )}
+    </section>
+  );
+};
+
+export default LoginPage;

--- a/frontend-web/src/services/api.js
+++ b/frontend-web/src/services/api.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'
+});
+
+export const healthcheck = async () => {
+  const response = await apiClient.get('/healthcheck');
+  return response.data;
+};
+
+export default apiClient;

--- a/frontend-web/tailwind.config.js
+++ b/frontend-web/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,jsx,ts,tsx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/frontend-web/vite.config.js
+++ b/frontend-web/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite-based React application configured with TailwindCSS and Auth0 provider
- add navigation, login, dashboard, and admin pages with an axios healthcheck API call and sample d3 metrics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc265a17ac83228b466e06a8ecdead