### PR TITLE
Add profile-filtered content API and surface in clients

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import cors from 'cors';
 import express from 'express';
 import morgan from 'morgan';
 import { env } from './config/env';
+import { router as contentRouter } from './routes/content';
 import { router as userRouter } from './routes/users';
 
 export function createApp() {
@@ -16,6 +17,7 @@ export function createApp() {
   });
 
   app.use('/users', userRouter);
+  app.use('/content', contentRouter);
 
   app.use((req, res) => {
     res.status(404).json({ message: `Route ${req.method} ${req.path} not found` });

--- a/backend/src/controllers/contentController.ts
+++ b/backend/src/controllers/contentController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import { contentService } from '../services/contentService';
+import { UserRole } from '../services/userService';
+
+const validProfiles: UserRole[] = ['admin', 'student'];
+
+type ListContentQuery = {
+  profile?: UserRole;
+};
+
+export function listContent(req: Request<unknown, unknown, unknown, ListContentQuery>, res: Response) {
+  const { profile } = req.query;
+
+  if (profile && !validProfiles.includes(profile)) {
+    return res.status(400).json({ message: `Invalid profile: ${profile}` });
+  }
+
+  const items = contentService.list(profile);
+
+  return res.json({ items });
+}

--- a/backend/src/routes/content.ts
+++ b/backend/src/routes/content.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { listContent } from '../controllers/contentController';
+
+export const router = Router();
+
+router.get('/', listContent);

--- a/backend/src/services/contentService.ts
+++ b/backend/src/services/contentService.ts
@@ -1,0 +1,54 @@
+import { UserRole } from './userService';
+
+export type ContentItem = {
+  id: string;
+  title: string;
+  description: string;
+  profiles: UserRole[];
+};
+
+const contentLibrary: ContentItem[] = [
+  {
+    id: 'budget-roadmap',
+    title: 'Roteiro de orçamento pessoal',
+    description:
+      'Passo a passo para organizar receitas e despesas da carreira médica sem comprometer a qualidade de vida.',
+    profiles: ['student', 'admin']
+  },
+  {
+    id: 'residency-investments',
+    title: 'Investimentos para residentes',
+    description: 'Estratégias de renda fixa e fundos imobiliários para quem está começando na residência.',
+    profiles: ['student']
+  },
+  {
+    id: 'clinic-cashflow',
+    title: 'Fluxo de caixa do consultório',
+    description: 'Checklist com previsões de despesas, repasses e metas de faturamento para clínicas em crescimento.',
+    profiles: ['admin']
+  },
+  {
+    id: 'tax-essentials',
+    title: 'Essenciais de tributação médica',
+    description: 'Entenda o impacto de regimes tributários como Lucro Presumido e Simples Nacional na rotina médica.',
+    profiles: ['student', 'admin']
+  },
+  {
+    id: 'team-performance',
+    title: 'Performance da equipe assistencial',
+    description: 'Métricas para acompanhar a produtividade do time e alinhar metas financeiras com qualidade assistencial.',
+    profiles: ['admin']
+  }
+];
+
+export class ContentService {
+  list(profile?: UserRole): Omit<ContentItem, 'profiles'>[] {
+    const items = profile
+      ? contentLibrary.filter((item) => item.profiles.includes(profile))
+      : contentLibrary;
+
+    return items.map(({ profiles, ...rest }) => rest);
+  }
+}
+
+export const contentService = new ContentService();

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -1,8 +1,10 @@
+export type UserRole = 'admin' | 'student';
+
 export type User = {
   id: string;
   name: string;
   email: string;
-  role: 'admin' | 'student';
+  role: UserRole;
 };
 
 const users: User[] = [

--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -21,4 +21,27 @@ describe('MedFinance API', () => {
       ]),
     );
   });
+
+  it('returns learning content filtered by profile', async () => {
+    const response = await request(app).get('/content').query({ profile: 'student' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: expect.any(String), title: expect.any(String), description: expect.any(String) }),
+      ]),
+    );
+    expect(response.body.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'clinic-cashflow' }),
+      ]),
+    );
+  });
+
+  it('validates unknown profiles on content route', async () => {
+    const response = await request(app).get('/content').query({ profile: 'guest' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ message: 'Invalid profile: guest' });
+  });
 });

--- a/frontend-mobile/src/__tests__/App.test.js
+++ b/frontend-mobile/src/__tests__/App.test.js
@@ -1,20 +1,79 @@
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import App from '../../App';
 
+const flushPromises = () => new Promise(resolve => setImmediate(resolve));
+
 describe('MedFinance mobile app', () => {
-  it('starts with zero balance', () => {
+  const mockContent = {
+    student: [
+      { id: 'budget-roadmap', title: 'Roteiro de orçamento pessoal', description: '...' },
+      { id: 'residency-investments', title: 'Investimentos para residentes', description: '...' },
+      { id: 'tax-essentials', title: 'Essenciais de tributação médica', description: '...' }
+    ],
+    admin: [
+      { id: 'budget-roadmap', title: 'Roteiro de orçamento pessoal', description: '...' },
+      { id: 'clinic-cashflow', title: 'Fluxo de caixa do consultório', description: '...' },
+      { id: 'tax-essentials', title: 'Essenciais de tributação médica', description: '...' }
+    ]
+  };
+
+  beforeEach(() => {
+    jest.spyOn(global, 'fetch').mockImplementation((url) => {
+      const profile = url.includes('profile=admin') ? 'admin' : 'student';
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ items: mockContent[profile] })
+      });
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('starts with zero balance', async () => {
     const { getByText } = render(<App />);
+
+    await act(async () => {
+      await flushPromises();
+    });
 
     expect(getByText(/Saldo atual: R\$0.00/)).toBeTruthy();
   });
 
-  it('updates balance when actions are pressed', () => {
+  it('updates balance when actions are pressed', async () => {
     const { getByText } = render(<App />);
+
+    await act(async () => {
+      await flushPromises();
+    });
 
     fireEvent.press(getByText('Adicionar R$100'));
     expect(getByText(/Saldo atual: R\$100.00/)).toBeTruthy();
 
     fireEvent.press(getByText('Remover R$50'));
     expect(getByText(/Saldo atual: R\$50.00/)).toBeTruthy();
+  });
+
+  it('shows recommended content for each profile', async () => {
+    const { getByText } = render(<App />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await waitFor(() => {
+      expect(getByText('Investimentos para residentes')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('Gestor'));
+      await flushPromises();
+    });
+
+    await waitFor(() => {
+      expect(getByText('Fluxo de caixa do consultório')).toBeTruthy();
+    });
   });
 });

--- a/frontend-web/src/__tests__/App.test.tsx
+++ b/frontend-web/src/__tests__/App.test.tsx
@@ -1,18 +1,83 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import { afterEach, beforeEach, vi } from 'vitest';
 import App from '../App';
 
 describe('App', () => {
-  it('renders hero copy', () => {
+  const mockContent = {
+    student: [
+      { id: 'budget-roadmap', title: 'Roteiro de orçamento pessoal', description: '...' },
+      { id: 'residency-investments', title: 'Investimentos para residentes', description: '...' },
+      { id: 'tax-essentials', title: 'Essenciais de tributação médica', description: '...' }
+    ],
+    admin: [
+      { id: 'budget-roadmap', title: 'Roteiro de orçamento pessoal', description: '...' },
+      { id: 'clinic-cashflow', title: 'Fluxo de caixa do consultório', description: '...' },
+      { id: 'tax-essentials', title: 'Essenciais de tributação médica', description: '...' },
+      { id: 'team-performance', title: 'Performance da equipe assistencial', description: '...' }
+    ]
+  } as const;
+
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockImplementation((input: RequestInfo) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const profile = url.includes('profile=admin') ? 'admin' : 'student';
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ items: mockContent[profile as 'admin' | 'student'] })
+      }) as unknown as Promise<Response>;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders hero copy', async () => {
     render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(screen.getByRole('heading', { name: 'MedFinance' })).toBeInTheDocument();
     expect(screen.getByText(/organizar suas finanças pessoais/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await waitFor(() => expect(screen.queryByText('Carregando recomendações...')).not.toBeInTheDocument());
+    });
   });
 
-  it('lists feature highlights', () => {
+  it('lists personalized recommendations for the default profile', async () => {
     render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
 
-    const cards = screen.getAllByRole('heading', { level: 3 });
+    const cards = await screen.findAllByRole('heading', { level: 3 });
     expect(cards).toHaveLength(3);
+    expect(screen.getByText('Investimentos para residentes')).toBeInTheDocument();
+  });
+
+  it('updates recommendations when profile changes', async () => {
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await screen.findByText('Investimentos para residentes');
+
+    await act(async () => {
+      await userEvent.selectOptions(screen.getByLabelText('Perfil:'), 'admin');
+    });
+
+    expect(await screen.findByText('Fluxo de caixa do consultório')).toBeInTheDocument();
+    const cards = screen.getAllByRole('heading', { level: 3 });
+    expect(cards).toHaveLength(4);
+
+    await act(async () => {
+      await waitFor(() => expect(screen.queryByText('Carregando recomendações...')).not.toBeInTheDocument());
+    });
   });
 });

--- a/frontend-web/src/components/FeatureGrid.tsx
+++ b/frontend-web/src/components/FeatureGrid.tsx
@@ -1,31 +1,90 @@
+import { useEffect, useState } from 'react';
 import FeatureCard from './FeatureCard';
 
-const features = [
-  {
-    title: 'Planejamento financeiro',
-    description: 'Modelos de orçamento adaptados à rotina da medicina para potencializar seus investimentos.'
-  },
-  {
-    title: 'Comunidade exclusiva',
-    description: 'Mentorias e encontros ao vivo com especialistas em finanças para profissionais da saúde.'
-  },
-  {
-    title: 'Ferramentas práticas',
-    description: 'Calculadoras e relatórios interativos para tomada de decisões com segurança.'
-  }
+type Profile = 'student' | 'admin';
+
+type ContentResponse = {
+  items: Array<{
+    id: string;
+    title: string;
+    description: string;
+  }>;
+};
+
+const profiles: Array<{ value: Profile; label: string }> = [
+  { value: 'student', label: 'Residente ou estudante' },
+  { value: 'admin', label: 'Gestor ou proprietário' }
 ];
 
-const FeatureGrid = () => (
-  <section className="features" id="features">
-    <div className="container">
-      <h2>Por que escolher a MedFinance?</h2>
-      <div className="grid">
-        {features.map((feature) => (
-          <FeatureCard key={feature.title} {...feature} />
-        ))}
+const apiBaseUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+
+const FeatureGrid = () => {
+  const [profile, setProfile] = useState<Profile>('student');
+  const [items, setItems] = useState<ContentResponse['items']>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    async function loadContent() {
+      setIsLoading(true);
+      try {
+        const response = await fetch(`${apiBaseUrl}/content?profile=${profile}`);
+        if (!response.ok) {
+          throw new Error('Falha ao carregar conteúdo');
+        }
+        const data: ContentResponse = await response.json();
+        if (active) {
+          setItems(data.items);
+          setError(null);
+        }
+      } catch (_error) {
+        if (active) {
+          setError('Não foi possível carregar o conteúdo agora. Tente novamente.');
+          setItems([]);
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadContent();
+
+    return () => {
+      active = false;
+    };
+  }, [profile]);
+
+  return (
+    <section className="features" id="features">
+      <div className="container">
+        <div className="feature-header">
+          <h2>Conteúdos recomendados para o seu momento</h2>
+          <label className="profile-selector">
+            <span>Perfil:</span>
+            <select value={profile} onChange={(event) => setProfile(event.target.value as Profile)}>
+              {profiles.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        {isLoading && <p className="status-message">Carregando recomendações...</p>}
+        {error && !isLoading && <p className="status-message error">{error}</p>}
+        {!isLoading && !error && (
+          <div className="grid">
+            {items.map((item) => (
+              <FeatureCard key={item.id} title={item.title} description={item.description} />
+            ))}
+          </div>
+        )}
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default FeatureGrid;

--- a/frontend-web/src/styles.css
+++ b/frontend-web/src/styles.css
@@ -69,6 +69,48 @@ html,
   margin-bottom: 2.5rem;
 }
 
+.feature-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.profile-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  background-color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  font-weight: 500;
+}
+
+.profile-selector select {
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.profile-selector select:focus {
+  outline: none;
+}
+
+.status-message {
+  text-align: center;
+  color: #475569;
+  margin: 1.5rem 0;
+}
+
+.status-message.error {
+  color: #dc2626;
+}
+
 .grid {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- add a dedicated content service/controller and expose a `/content` route that validates profile filters
- update the web landing page to fetch profile-specific recommendations with loading and error states
- extend the mobile dashboard with profile-based content cards and refreshed tests for both clients

## Testing
- npm test --prefix backend
- npm test --prefix frontend-web
- npm test --prefix frontend-mobile

------
https://chatgpt.com/codex/tasks/task_e_68ddde17f2f08322b812796ce1f31159