### PR TITLE
Fix TypeScript setup for tests

### DIFF
--- a/frontend-web/src/vite-env.d.ts
+++ b/frontend-web/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+export {};

--- a/frontend-web/tsconfig.json
+++ b/frontend-web/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["node", "vitest/globals", "vite/client", "@testing-library/jest-dom"]
   },
   "include": ["src", "vite.config.ts", "vitest.setup.ts"],
   "references": []


### PR DESCRIPTION
## Summary
- include Node, Vitest, and Vite client types in the frontend web TypeScript config
- add the Vite env type declaration file so import.meta.env is typed during tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dde0c2618c83229978e71061d73b38