### PR TITLE
Fix frontend build tsconfig type references

### DIFF
--- a/frontend-web/tsconfig.json
+++ b/frontend-web/tsconfig.json
@@ -11,8 +11,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client"],
+    "noEmit": true
   },
-  "include": ["src", "vite.config.ts", "vitest.setup.ts"],
-  "references": []
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__"]
 }

--- a/frontend-web/tsconfig.vitest.json
+++ b/frontend-web/tsconfig.vitest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vitest.setup.ts", "vite.config.ts"],
+  "exclude": []
+}

--- a/frontend-web/vite.config.ts
+++ b/frontend-web/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: './vitest.setup.ts'
+    setupFiles: './vitest.setup.ts',
+    typecheck: {
+      tsconfig: './tsconfig.vitest.json'
+    }
   }
 });


### PR DESCRIPTION
## Summary
- prevent the production TypeScript build from referencing Vitest-only type packages and emitting JS artefacts
- add a dedicated Vitest tsconfig that re-enables the test type definitions and exposes the project config for test runs
- point the Vitest runner at the new tsconfig from the Vite configuration for consistent type checking

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dde1fd1958832282dc4db388f645e7