### PR TITLE
fix: include react types in dependencies

### DIFF
--- a/frontend-web/package-lock.json
+++ b/frontend-web/package-lock.json
@@ -8,6 +8,8 @@
       "name": "medfinance-frontend-web",
       "version": "1.0.0",
       "dependencies": {
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -15,8 +17,6 @@
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.3.1",
         "@testing-library/user-event": "^14.5.2",
-        "@types/react": "^18.3.3",
-        "@types/react-dom": "^18.3.2",
         "@vitejs/plugin-react": "^4.3.1",
         "jsdom": "^24.1.0",
         "typescript": "^5.5.4",
@@ -1389,14 +1389,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
       "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1407,7 +1405,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -1897,7 +1894,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {

--- a/frontend-web/package.json
+++ b/frontend-web/package.json
@@ -10,6 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -17,8 +19,6 @@
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.2",
     "@vitejs/plugin-react": "^4.3.1",
     "jsdom": "^24.1.0",
     "typescript": "^5.5.4",


### PR DESCRIPTION
## Summary
- move the React type definition packages from devDependencies to dependencies so they are always installed
- update the lockfile to reflect the dependency changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dde7b1a2ac8322a34ed2fb1f059b60