### PR TITLE
Add persistent theme provider with header toggle

### DIFF
--- a/frontend-web/src/App.tsx
+++ b/frontend-web/src/App.tsx
@@ -1,9 +1,11 @@
+import Header from './components/Header';
 import Hero from './components/Hero';
 import FeatureGrid from './components/FeatureGrid';
 
 function App() {
   return (
     <div className="app">
+      <Header />
       <Hero />
       <FeatureGrid />
     </div>

--- a/frontend-web/src/components/Header.tsx
+++ b/frontend-web/src/components/Header.tsx
@@ -1,0 +1,28 @@
+import { useThemeMode } from '../theme/useThemeMode';
+
+const Header = () => {
+  const { theme, toggleTheme } = useThemeMode();
+  const isDark = theme === 'dark';
+
+  return (
+    <header className="site-header">
+      <div className="container header-content">
+        <span className="logo">MedFinance</span>
+        <button
+          type="button"
+          className="theme-toggle"
+          aria-label={isDark ? 'Ativar tema claro' : 'Ativar tema escuro'}
+          title={isDark ? 'Ativar tema claro' : 'Ativar tema escuro'}
+          onClick={toggleTheme}
+        >
+          <span className="visually-hidden">Alternar tema</span>
+          <span aria-hidden="true" className="theme-toggle__icon">
+            {isDark ? '🌙' : '☀️'}
+          </span>
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend-web/src/components/Hero.tsx
+++ b/frontend-web/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 const Hero = () => (
-  <header className="hero">
+  <section className="hero">
     <div className="container">
       <h1>MedFinance</h1>
       <p>
@@ -10,7 +10,7 @@ const Hero = () => (
         Conheça nossos recursos
       </a>
     </div>
-  </header>
+  </section>
 );
 
 export default Hero;

--- a/frontend-web/src/main.tsx
+++ b/frontend-web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ThemeProvider } from './theme/ThemeProvider';
 import './styles.css';
 
 const rootElement = document.getElementById('root');
@@ -11,6 +12,8 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/frontend-web/src/styles.css
+++ b/frontend-web/src/styles.css
@@ -1,14 +1,46 @@
 :root {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f8fafc;
-  color: #0f172a;
+  color-scheme: light;
+  --color-background: #f8fafc;
+  --color-text: #0f172a;
+  --color-muted: #475569;
+  --color-hero-background: linear-gradient(135deg, #1d4ed8 0%, #22d3ee 100%);
+  --color-hero-text: #ffffff;
+  --color-card-background: #ffffff;
+  --color-card-shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
+  --color-cta-background: #0f172a;
+  --color-cta-text: #ffffff;
+  --color-header-border: rgba(15, 23, 42, 0.08);
+  --color-toggle-background: rgba(15, 23, 42, 0.08);
+  --color-toggle-icon: #0f172a;
 }
 
-body,
+html.dark {
+  color-scheme: dark;
+  --color-background: #0f172a;
+  --color-text: #e2e8f0;
+  --color-muted: #94a3b8;
+  --color-hero-background: linear-gradient(135deg, #0f172a 0%, #1d4ed8 100%);
+  --color-hero-text: #f8fafc;
+  --color-card-background: #1f2937;
+  --color-card-shadow: 0 20px 50px rgba(15, 23, 42, 0.4);
+  --color-cta-background: #e2e8f0;
+  --color-cta-text: #0f172a;
+  --color-header-border: rgba(148, 163, 184, 0.3);
+  --color-toggle-background: rgba(148, 163, 184, 0.2);
+  --color-toggle-icon: #f8fafc;
+}
+
 html,
+body,
 #root {
   margin: 0;
   min-height: 100%;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
 .app {
@@ -23,9 +55,70 @@ html,
   padding: 0 1.5rem;
 }
 
+.site-header {
+  border-bottom: 1px solid var(--color-header-border);
+  background-color: var(--color-background);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(6px);
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: var(--color-toggle-background);
+  color: var(--color-toggle-icon);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+
+.theme-toggle__icon {
+  font-size: 1.25rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .hero {
-  background: linear-gradient(135deg, #1d4ed8 0%, #22d3ee 100%);
-  color: white;
+  background: var(--color-hero-background);
+  color: var(--color-hero-text);
   padding: 4rem 0 6rem;
 }
 
@@ -39,14 +132,15 @@ html,
   line-height: 1.6;
   margin-bottom: 2rem;
   max-width: 48ch;
+  color: var(--color-hero-text);
 }
 
 .cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: #0f172a;
-  color: white;
+  background-color: var(--color-cta-background);
+  color: var(--color-cta-text);
   border-radius: 999px;
   padding: 0.75rem 1.5rem;
   font-weight: 600;
@@ -61,6 +155,7 @@ html,
 
 .features {
   padding-bottom: 6rem;
+  color: var(--color-text);
 }
 
 .features h2 {
@@ -76,10 +171,10 @@ html,
 }
 
 .feature-card {
-  background-color: white;
+  background-color: var(--color-card-background);
   border-radius: 1rem;
   padding: 1.75rem;
-  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--color-card-shadow);
   transition: transform 0.2s ease;
 }
 
@@ -95,4 +190,5 @@ html,
 .feature-card p {
   margin: 0;
   line-height: 1.6;
+  color: var(--color-muted);
 }

--- a/frontend-web/src/theme/ThemeProvider.tsx
+++ b/frontend-web/src/theme/ThemeProvider.tsx
@@ -1,0 +1,107 @@
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  setTheme: (mode: ThemeMode) => void;
+  toggleTheme: () => void;
+}
+
+const STORAGE_KEY = 'theme';
+
+function getStoredTheme(): ThemeMode | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  return null;
+}
+
+function getSystemTheme(): ThemeMode {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemeMode>(() => getStoredTheme() ?? getSystemTheme());
+  const [isUserPreference, setIsUserPreference] = useState<boolean>(() => getStoredTheme() !== null);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  useEffect(() => {
+    if (!isUserPreference || typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [isUserPreference, theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (!isUserPreference) {
+        setThemeState(event.matches ? 'dark' : 'light');
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [isUserPreference]);
+
+  const setTheme = useCallback((mode: ThemeMode) => {
+    setIsUserPreference(true);
+    setThemeState(mode);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setIsUserPreference(true);
+    setThemeState((current: ThemeMode) => (current === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [setTheme, theme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/frontend-web/src/theme/useThemeMode.ts
+++ b/frontend-web/src/theme/useThemeMode.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { ThemeContext } from './ThemeProvider';
+
+export function useThemeMode() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useThemeMode must be used within a ThemeProvider');
+  }
+
+  return context;
+}

--- a/frontend-web/tsconfig.json
+++ b/frontend-web/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"],
+    "types": ["vite/client", "react", "react-dom"],
     "noEmit": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
## Summary
- add a ThemeProvider that follows the system color scheme, persists overrides, and updates the document class
- expose a useThemeMode hook and render a header toggle to switch between light and dark icons
- refresh global styles to support light and dark palettes via CSS variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddebf1b3308322948573508a414e95