### PR TITLE
feat(frontend-web): add responsive appshell layout

### DIFF
--- a/frontend-web/src/App.tsx
+++ b/frontend-web/src/App.tsx
@@ -1,12 +1,18 @@
-import Hero from './components/Hero';
+import AppShell from './components/AppShell';
 import FeatureGrid from './components/FeatureGrid';
+import Hero from './components/Hero';
+
+const user = {
+  name: 'Ana Silva',
+  role: 'admin' as const,
+};
 
 function App() {
   return (
-    <div className="app">
+    <AppShell user={user}>
       <Hero />
       <FeatureGrid />
-    </div>
+    </AppShell>
   );
 }
 

--- a/frontend-web/src/components/AppShell.css
+++ b/frontend-web/src/components/AppShell.css
@@ -1,0 +1,379 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+  line-height: 1.5;
+}
+
+[data-theme='dark'] {
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+[data-theme='dark'] body {
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+body,
+html,
+#root {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  background-color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 1rem;
+  background: #2563eb;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  z-index: 2000;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 1rem;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background-color: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 1010;
+  backdrop-filter: blur(8px);
+}
+
+[data-theme='dark'] .app-shell__header {
+  background-color: rgba(15, 23, 42, 0.95);
+}
+
+.app-shell__menu-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: inherit;
+}
+
+@media (min-width: 1024px) {
+  .app-shell__menu-button {
+    display: none;
+  }
+}
+
+.icon-button {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.app-shell__logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.125rem;
+}
+
+.app-shell__search {
+  display: flex;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  width: 100%;
+}
+
+.app-shell__search input {
+  border: none;
+  background: none;
+  color: inherit;
+  width: 100%;
+  padding: 0.5rem;
+  font: inherit;
+}
+
+.app-shell__search input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.app-shell__search input:focus {
+  outline: none;
+}
+
+.app-shell__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.app-shell__avatar {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  background-color: rgba(255, 255, 255, 0.1);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.app-shell__body {
+  position: relative;
+  flex: 1;
+}
+
+.app-shell__sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: min(280px, 80vw);
+  background-color: #0f172a;
+  color: #e2e8f0;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+}
+
+[data-theme='dark'] .app-shell__sidebar {
+  background-color: #020617;
+}
+
+.app-shell__sidebar nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.app-shell__sidebar a {
+  color: inherit;
+  text-decoration: none;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  display: block;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.app-shell__sidebar a:focus-visible,
+.app-shell__sidebar a:hover {
+  background-color: rgba(148, 163, 184, 0.2);
+  color: #fff;
+}
+
+.app-shell__sidebar--open {
+  transform: translateX(0);
+}
+
+.app-shell__overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.5);
+  z-index: 900;
+}
+
+.app-shell__content {
+  padding: 2rem 1.5rem 3rem;
+}
+
+@media (min-width: 768px) {
+  .app-shell__header {
+    grid-template-columns: auto minmax(280px, 1fr) auto;
+  }
+
+  .app-shell__content {
+    padding: 2.5rem 3rem 4rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .app-shell__body {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    column-gap: 2rem;
+    align-items: start;
+  }
+
+  .app-shell__sidebar {
+    position: sticky;
+    top: 1.5rem;
+    align-self: start;
+    height: calc(100vh - 1.5rem);
+    transform: none;
+    width: 100%;
+    inset: auto;
+  }
+
+  .app-shell__overlay {
+    display: none;
+  }
+
+  .app-shell__content {
+    padding: 3rem 4rem 4rem;
+    margin-left: 0;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.hero,
+.features {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero {
+  background: linear-gradient(135deg, #1d4ed8 0%, #22d3ee 100%);
+  color: white;
+  border-radius: 1.5rem;
+  padding: 3rem;
+  margin-bottom: 2rem;
+}
+
+.hero .container {
+  padding: 0;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+  max-width: 48ch;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f172a;
+  color: white;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+}
+
+.features {
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 1.5rem;
+  padding: 3rem;
+}
+
+[data-theme='dark'] .features {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.features h2 {
+  text-align: center;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  margin-bottom: 2.5rem;
+}
+
+.container {
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card {
+  background-color: white;
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease;
+}
+
+[data-theme='dark'] .feature-card {
+  background-color: rgba(15, 23, 42, 0.8);
+  color: #e2e8f0;
+  box-shadow: none;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.feature-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.feature-card p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+}

--- a/frontend-web/src/components/AppShell.tsx
+++ b/frontend-web/src/components/AppShell.tsx
@@ -1,0 +1,185 @@
+import { ReactNode, useEffect, useMemo, useState } from 'react';
+import './AppShell.css';
+
+type NavigationItem = {
+  label: string;
+  href: string;
+};
+
+type User = {
+  name: string;
+  role: 'user' | 'admin';
+};
+
+type AppShellProps = {
+  children: ReactNode;
+  user: User;
+};
+
+const NAVIGATION: NavigationItem[] = [
+  { label: 'Dashboard', href: '#dashboard' },
+  { label: 'Cursos', href: '#courses' },
+  { label: 'Comunidade', href: '#community' },
+  { label: 'Financeiro', href: '#finance' },
+];
+
+const ADMIN_ITEM: NavigationItem = { label: 'Admin', href: '#admin' };
+
+export default function AppShell({ children, user }: AppShellProps) {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isDarkTheme, setIsDarkTheme] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDarkTheme) {
+      root.setAttribute('data-theme', 'dark');
+    } else {
+      root.removeAttribute('data-theme');
+    }
+  }, [isDarkTheme]);
+
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsSidebarOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, [isSidebarOpen]);
+
+  useEffect(() => {
+    if (!window.matchMedia) {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(min-width: 1024px)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        setIsSidebarOpen(false);
+      }
+    };
+
+    if (mediaQuery.matches) {
+      setIsSidebarOpen(false);
+    }
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const navigation = useMemo(() => {
+    if (user.role === 'admin') {
+      return [...NAVIGATION, ADMIN_ITEM];
+    }
+
+    return NAVIGATION;
+  }, [user.role]);
+
+  return (
+    <div className="app-shell">
+      <a href="#main" className="skip-link">
+        Pular para o conteúdo principal
+      </a>
+      <header className="app-shell__header" role="banner">
+        <button
+          type="button"
+          className="icon-button app-shell__menu-button"
+          aria-label={isSidebarOpen ? 'Fechar menu de navegação' : 'Abrir menu de navegação'}
+          aria-expanded={isSidebarOpen}
+          aria-controls="app-sidebar"
+          onClick={() => setIsSidebarOpen((prev) => !prev)}
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
+
+        <div className="app-shell__logo" aria-label="MedFinance">
+          <span aria-hidden="true">💊</span>
+          <span>MedFinance</span>
+        </div>
+
+        <form
+          className="app-shell__search"
+          role="search"
+          aria-label="Buscar cursos e conteúdos"
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <label htmlFor="global-search" className="sr-only">
+            Buscar
+          </label>
+          <input
+            id="global-search"
+            type="search"
+            placeholder="Buscar..."
+            aria-label="Buscar"
+          />
+        </form>
+
+        <div className="app-shell__actions" role="group" aria-label="Ações do usuário">
+          <button
+            type="button"
+            className="icon-button"
+            aria-pressed={isDarkTheme}
+            aria-label={isDarkTheme ? 'Ativar tema claro' : 'Ativar tema escuro'}
+            onClick={() => setIsDarkTheme((prev) => !prev)}
+          >
+            <span aria-hidden="true">{isDarkTheme ? '🌙' : '☀️'}</span>
+          </button>
+          <button type="button" className="app-shell__avatar" aria-label={`Abrir menu do usuário ${user.name}`}>
+            <span aria-hidden="true">{getInitials(user.name)}</span>
+          </button>
+        </div>
+      </header>
+
+      <div className="app-shell__body">
+        <aside
+          id="app-sidebar"
+          className={`app-shell__sidebar ${isSidebarOpen ? 'app-shell__sidebar--open' : ''}`}
+          aria-label="Navegação principal"
+        >
+          <nav>
+            <ul>
+              {navigation.map((item) => (
+                <li key={item.label}>
+                  <a
+                    href={item.href}
+                    onClick={() => setIsSidebarOpen(false)}
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </aside>
+
+        {isSidebarOpen && (
+          <div
+            className="app-shell__overlay"
+            role="presentation"
+            aria-hidden="true"
+            onClick={() => setIsSidebarOpen(false)}
+          />
+        )}
+
+        <main id="main" tabIndex={-1} className="app-shell__content" aria-label="Conteúdo principal">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function getInitials(name: string) {
+  return name
+    .split(' ')
+    .map((part) => part.charAt(0).toUpperCase())
+    .slice(0, 2)
+    .join('');
+}

--- a/frontend-web/src/styles.css
+++ b/frontend-web/src/styles.css
@@ -1,7 +1,12 @@
 :root {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
   background-color: #f8fafc;
   color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body,
@@ -11,88 +16,10 @@ html,
   min-height: 100%;
 }
 
-.app {
-  display: flex;
-  flex-direction: column;
-  gap: 3rem;
+body {
+  background-color: inherit;
 }
 
-.container {
-  width: min(960px, 100%);
-  margin: 0 auto;
-  padding: 0 1.5rem;
-}
-
-.hero {
-  background: linear-gradient(135deg, #1d4ed8 0%, #22d3ee 100%);
-  color: white;
-  padding: 4rem 0 6rem;
-}
-
-.hero h1 {
-  font-size: clamp(2.5rem, 5vw, 3.5rem);
-  margin-bottom: 1rem;
-}
-
-.hero p {
-  font-size: 1.1rem;
-  line-height: 1.6;
-  margin-bottom: 2rem;
-  max-width: 48ch;
-}
-
-.cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background-color: #0f172a;
-  color: white;
-  border-radius: 999px;
-  padding: 0.75rem 1.5rem;
-  font-weight: 600;
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.cta:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
-}
-
-.features {
-  padding-bottom: 6rem;
-}
-
-.features h2 {
-  text-align: center;
-  font-size: clamp(2rem, 4vw, 2.5rem);
-  margin-bottom: 2.5rem;
-}
-
-.grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.feature-card {
-  background-color: white;
-  border-radius: 1rem;
-  padding: 1.75rem;
-  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
-  transition: transform 0.2s ease;
-}
-
-.feature-card:hover {
-  transform: translateY(-4px);
-}
-
-.feature-card h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-}
-
-.feature-card p {
-  margin: 0;
-  line-height: 1.6;
+a {
+  color: inherit;
 }

--- a/frontend-web/tsconfig.json
+++ b/frontend-web/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"],
+    "types": ["vite/client", "react", "react-dom"],
     "noEmit": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
## Summary
- implement an AppShell layout with sticky header, responsive sidebar, and accessibility enhancements
- wrap existing marketing sections with the new shell and add theme toggle and user avatar controls
- centralize styling in a dedicated stylesheet and update TypeScript config for React type definitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddec04f98c83229f2b101b58657fc1