### PR TITLE
fix(frontend-web): resolve styles.css merge conflict

### DIFF
--- a/frontend-web/src/main.tsx
+++ b/frontend-web/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import './styles/index.css';
+import './styles.css';
 
 const rootElement = document.getElementById('root');
 

--- a/frontend-web/src/styles.css
+++ b/frontend-web/src/styles.css
@@ -1,4 +1,4 @@
-@import './tokens.css';
+@import './styles/tokens.css';
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- restore the frontend global stylesheet at `src/styles.css` while keeping the Tailwind token setup
- update the React entry point to load the consolidated stylesheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de777699448322bcd6ad3e99bc6aa4