### PR TITLE
Add npm workspace scripts for MedFinance monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ que garante que todos os projetos continuam compilando e com testes verdes.
 
 ## Estrutura do repositório
 
+- `package.json`: arquivo de workspaces que permite rodar scripts globais como `npm test` e `npm run build` na raiz.
 - `backend/`: API em Node.js + Express escrita em TypeScript com rotas básicas e camada de serviço de usuários.
 - `frontend-web/`: aplicação web React (Vite) com página institucional e testes usando React Testing Library + Vitest.
 - `frontend-mobile/`: aplicativo React Native com Expo e testes usando React Native Testing Library.
@@ -16,6 +17,17 @@ que garante que todos os projetos continuam compilando e com testes verdes.
 - Node.js 18+
 - npm 9+
 - (Opcional) Expo CLI (`npm install -g expo-cli`) para executar o app mobile em dispositivos/simuladores.
+
+## Scripts globais
+
+O repositório utiliza workspaces do npm para facilitar comandos que englobam todos os projetos. Alguns exemplos a partir da raiz:
+
+```bash
+npm test      # executa os testes de backend, frontend web e mobile
+npm run build # compila backend e frontend web
+```
+
+Para desenvolver localmente, execute os scripts `npm run dev` em cada workspace individualmente.
 
 ## Backend
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "medfinance-monorepo",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Monorepositório da plataforma MedFinance com backend, frontend web e aplicativo mobile.",
+  "workspaces": [
+    "backend",
+    "frontend-web",
+    "frontend-mobile"
+  ],
+  "scripts": {
+    "test": "npm run test --workspaces --if-present",
+    "build": "npm run build --workspace backend && npm run build --workspace frontend-web",
+    "dev": "echo 'Execute os servidores individuais com npm run dev em cada workspace.'",
+    "lint": "npm run lint --workspaces --if-present",
+    "format": "npm run format --workspaces --if-present",
+    "ci": "npm run test && npm run build"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root `package.json` configuring npm workspaces for the backend, frontend web, and mobile apps
- document the new global scripts in the repository README to highlight running tests and builds from the monorepo root

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de918899f083228494ee4ba39aba30