### PR TITLE
Configure Git LFS for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.ai filter=lfs diff=lfs merge=lfs -text
+*.fig filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.docx filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- enable Git LFS hooks in the repository
- track common binary asset formats (.png, .jpg, .pdf, .docx, .psd, .ai, .fig)

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9aedc16c8322b3e2894c1038eb9c