### PR TITLE
Add finance simulator endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import cors from 'cors';
 import express from 'express';
 import morgan from 'morgan';
 import { env } from './config/env';
+import { router as financeRouter } from './routes/finance';
 import { router as userRouter } from './routes/users';
 
 export function createApp() {
@@ -16,6 +17,7 @@ export function createApp() {
   });
 
   app.use('/users', userRouter);
+  app.use('/finance', financeRouter);
 
   app.use((req, res) => {
     res.status(404).json({ message: `Route ${req.method} ${req.path} not found` });

--- a/backend/src/controllers/financeSimulatorController.ts
+++ b/backend/src/controllers/financeSimulatorController.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from 'express';
+import { financeSimulatorService } from '../services/financeSimulatorService';
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function simulateFinance(req: Request, res: Response) {
+  const { loanAmount, annualInterestRate, loanTermMonths, extraPayment } = req.body ?? {};
+
+  const errors: string[] = [];
+
+  if (!isNumber(loanAmount) || loanAmount <= 0) {
+    errors.push('loanAmount must be a positive number');
+  }
+
+  if (!isNumber(annualInterestRate) || annualInterestRate < 0) {
+    errors.push('annualInterestRate must be a non-negative number');
+  }
+
+  if (!isNumber(loanTermMonths) || loanTermMonths <= 0) {
+    errors.push('loanTermMonths must be a positive number');
+  }
+
+  if (extraPayment !== undefined) {
+    if (!isNumber(extraPayment) || extraPayment < 0) {
+      errors.push('extraPayment must be a non-negative number when provided');
+    }
+  }
+
+  if (errors.length > 0) {
+    return res.status(400).json({ message: 'Invalid request data', errors });
+  }
+
+  const result = financeSimulatorService.simulate({
+    loanAmount,
+    annualInterestRate,
+    loanTermMonths,
+    extraPayment,
+  });
+
+  return res.json(result);
+}

--- a/backend/src/routes/finance.ts
+++ b/backend/src/routes/finance.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { simulateFinance } from '../controllers/financeSimulatorController';
+
+export const router = Router();
+
+router.post('/simulator', simulateFinance);

--- a/backend/src/services/financeSimulatorService.ts
+++ b/backend/src/services/financeSimulatorService.ts
@@ -1,0 +1,97 @@
+export interface FinanceSimulationInput {
+  loanAmount: number;
+  annualInterestRate: number;
+  loanTermMonths: number;
+  extraPayment?: number;
+}
+
+export interface FinanceSimulationScheduleEntry {
+  month: number;
+  payment: number;
+  principal: number;
+  interest: number;
+  remainingBalance: number;
+}
+
+export interface FinanceSimulationResult {
+  monthlyPayment: number;
+  totalInterestPaid: number;
+  totalAmountPaid: number;
+  payoffMonths: number;
+  schedule: FinanceSimulationScheduleEntry[];
+}
+
+function roundCurrency(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export class FinanceSimulatorService {
+  simulate(input: FinanceSimulationInput): FinanceSimulationResult {
+    const { loanAmount, annualInterestRate, loanTermMonths, extraPayment = 0 } = input;
+
+    const monthlyRate = annualInterestRate === 0 ? 0 : annualInterestRate / 12 / 100;
+    const baseMonthlyPayment =
+      monthlyRate === 0
+        ? loanAmount / loanTermMonths
+        : (loanAmount * monthlyRate) / (1 - Math.pow(1 + monthlyRate, -loanTermMonths));
+
+    let balance = loanAmount;
+    let month = 0;
+    let totalInterestPaid = 0;
+    const schedule: FinanceSimulationScheduleEntry[] = [];
+
+    while (balance > 0 && month < loanTermMonths) {
+      month += 1;
+      const interestPayment = monthlyRate === 0 ? 0 : balance * monthlyRate;
+      let principalPayment = baseMonthlyPayment - interestPayment;
+      let payment = baseMonthlyPayment;
+
+      if (extraPayment > 0) {
+        payment += extraPayment;
+        principalPayment += extraPayment;
+      }
+
+      if (principalPayment > balance) {
+        principalPayment = balance;
+        payment = interestPayment + balance;
+      }
+
+      const roundedInterest = roundCurrency(interestPayment);
+      const roundedPrincipal = roundCurrency(principalPayment);
+      const roundedPayment = roundCurrency(roundedInterest + roundedPrincipal);
+
+      balance = roundCurrency(balance - roundedPrincipal);
+      if (balance < 0) {
+        balance = 0;
+      }
+
+      totalInterestPaid = roundCurrency(totalInterestPaid + roundedInterest);
+
+      schedule.push({
+        month,
+        payment: roundedPayment,
+        principal: roundedPrincipal,
+        interest: roundedInterest,
+        remainingBalance: balance,
+      });
+
+      if (balance === 0) {
+        break;
+      }
+    }
+
+    const totalAmountPaid = roundCurrency(
+      schedule.reduce((sum, entry) => sum + entry.payment, 0),
+    );
+
+    return {
+      monthlyPayment: roundCurrency(baseMonthlyPayment),
+      totalInterestPaid,
+      totalAmountPaid,
+      payoffMonths: schedule.length,
+      schedule,
+    };
+  }
+}
+
+export const financeSimulatorService = new FinanceSimulatorService();

--- a/backend/tests/financeSimulator.test.ts
+++ b/backend/tests/financeSimulator.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+describe('Finance simulator endpoint', () => {
+  const app = createApp();
+
+  it('returns an amortization schedule for valid input', async () => {
+    const response = await request(app).post('/finance/simulator').send({
+      loanAmount: 100000,
+      annualInterestRate: 6,
+      loanTermMonths: 360,
+      extraPayment: 100,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.monthlyPayment).toBeCloseTo(599.55, 2);
+    expect(response.body.totalInterestPaid).toBeCloseTo(75937.97, 2);
+    expect(response.body.totalAmountPaid).toBeCloseTo(175937.97, 2);
+    expect(response.body.payoffMonths).toBe(252);
+
+    const firstInstallment = response.body.schedule[0];
+    expect(firstInstallment.month).toBe(1);
+    expect(firstInstallment.payment).toBeCloseTo(699.55, 2);
+    expect(firstInstallment.principal).toBeCloseTo(199.55, 2);
+    expect(firstInstallment.interest).toBeCloseTo(500, 2);
+    expect(firstInstallment.remainingBalance).toBeCloseTo(99800.45, 2);
+  });
+
+  it('returns 400 when payload is invalid', async () => {
+    const response = await request(app).post('/finance/simulator').send({
+      loanAmount: -1000,
+      annualInterestRate: 'five',
+      loanTermMonths: 0,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        message: 'Invalid request data',
+        errors: expect.arrayContaining([
+          'loanAmount must be a positive number',
+          'annualInterestRate must be a non-negative number',
+          'loanTermMonths must be a positive number',
+        ]),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a finance simulator service, controller, and route to expose POST /finance/simulator
- implement amortization calculations with validation for input data
- add integration tests covering success and invalid payload scenarios

## Testing
- npm test --workspace backend
- npm run build --workspace backend

------
https://chatgpt.com/codex/tasks/task_e_68df2dfeea6883229dce89e6081160d6