### PR TITLE
Add consolidated CI workflow for workspace checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,68 +5,41 @@ on:
     branches: ['**']
   pull_request:
 
+env:
+  NODE_VERSION: 18
+
 jobs:
-  install:
-    name: Install dependencies
+  quality-checks:
+    name: ${{ matrix.project }} checks
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: [backend, frontend-web, frontend-mobile]
+        include:
+          - project: backend
+            test_command: npm test -- --runInBand
+            build_command: npm run build
+          - project: frontend-web
+            test_command: npm test
+            build_command: npm run build
+          - project: frontend-mobile
+            test_command: npm test -- --runInBand
+            build_command: ''
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: ${{ matrix.project }}/package-lock.json
-      - name: Install
+      - name: Install dependencies
         working-directory: ${{ matrix.project }}
-        run: npm install
-
-  test:
-    name: Run tests
-    needs: install
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - project: backend
-            command: npm test -- --runInBand
-          - project: frontend-web
-            command: npm test
-          - project: frontend-mobile
-            command: npm test -- --runInBand
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - name: Install
+        run: npm ci
+      - name: Run tests
         working-directory: ${{ matrix.project }}
-        run: npm install
-      - name: Test
-        working-directory: ${{ matrix.project }}
-        run: ${{ matrix.command }}
-
-  build:
-    name: Build apps
-    needs: test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - project: backend
-            command: npm run build
-          - project: frontend-web
-            command: npm run build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - name: Install
-        working-directory: ${{ matrix.project }}
-        run: npm install
+        env:
+          CI: true
+        run: ${{ matrix.test_command }}
       - name: Build
+        if: ${{ matrix.build_command != '' }}
         working-directory: ${{ matrix.project }}
-        run: ${{ matrix.command }}
+        run: ${{ matrix.build_command }}


### PR DESCRIPTION
## Summary
- replace the multi-job workflow with a single matrix that runs per workspace
- use npm ci with shared Node setup and cache configuration for repeatable installs
- keep build steps for backend and web apps while running tests for all packages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26f5fc2a0832292efd46e606204e9