### PR TITLE
feat: enable real-time simulation recalculation

### DIFF
--- a/mobile/src/screens/SimulatorScreen.tsx
+++ b/mobile/src/screens/SimulatorScreen.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import type { SimulationInput, SimulationResult } from '../../../shared/api/simulator';
+import { buildFallbackResult, simulateFinancialPlan } from '../../../shared/api/simulator';
+
+const DEBOUNCE_DELAY = 300;
+const API_ENDPOINT = '/api/simulator';
+
+const initialState: SimulationInput = {
+  monthlyIncome: 30000,
+  monthlyExpenses: 18000,
+  investmentRate: 0.1,
+};
+
+export function SimulatorScreen() {
+  const [form, setForm] = useState<SimulationInput>(initialState);
+  const [result, setResult] = useState<SimulationResult>(buildFallbackResult(initialState));
+  const [isCalculating, setIsCalculating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    setIsCalculating(true);
+    setError(null);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(async () => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+
+      const abortController = new AbortController();
+      abortRef.current = abortController;
+
+      try {
+        const data = await simulateFinancialPlan(API_ENDPOINT, form, abortController.signal);
+        setResult(data);
+      } catch (err) {
+        console.error(err);
+        setResult(buildFallbackResult(form));
+        setError('Não foi possível atualizar a simulação. Exibindo estimativa.');
+      } finally {
+        setIsCalculating(false);
+      }
+    }, DEBOUNCE_DELAY);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+    };
+  }, [form]);
+
+  function handleChange(key: keyof SimulationInput, value: string) {
+    setForm((previous) => ({
+      ...previous,
+      [key]: Number(value),
+    }));
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Simulador Financeiro</Text>
+      <Text style={styles.subtitle}>Atualize os valores e acompanhe o cálculo em tempo real.</Text>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Renda mensal</Text>
+        <TextInput
+          keyboardType="numeric"
+          style={styles.input}
+          value={String(form.monthlyIncome)}
+          onChangeText={(value) => handleChange('monthlyIncome', value)}
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Despesas mensais</Text>
+        <TextInput
+          keyboardType="numeric"
+          style={styles.input}
+          value={String(form.monthlyExpenses)}
+          onChangeText={(value) => handleChange('monthlyExpenses', value)}
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Taxa de investimento anual</Text>
+        <TextInput
+          keyboardType="numeric"
+          style={styles.input}
+          value={String(form.investmentRate)}
+          onChangeText={(value) => handleChange('investmentRate', value)}
+        />
+      </View>
+
+      {isCalculating ? (
+        <View style={styles.loading}>
+          <ActivityIndicator size="small" />
+          <Text style={styles.loadingText}>calculando...</Text>
+        </View>
+      ) : (
+        <View style={styles.result}>
+          <Text style={styles.resultLabel}>Poupança mensal</Text>
+          <Text style={styles.resultValue}>
+            {result.monthlySavings.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+          </Text>
+
+          <Text style={styles.resultLabel}>Poupança anual</Text>
+          <Text style={styles.resultValue}>
+            {result.annualSavings.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+          </Text>
+
+          <Text style={styles.resultLabel}>Retorno do investimento</Text>
+          <Text style={styles.resultValue}>
+            {result.investmentReturn.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+          </Text>
+        </View>
+      )}
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+    gap: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+  },
+  subtitle: {
+    color: '#4a5568',
+  },
+  field: {
+    gap: 8,
+  },
+  label: {
+    fontWeight: '500',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5e0',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  loading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  loadingText: {
+    textTransform: 'lowercase',
+  },
+  result: {
+    gap: 12,
+    borderRadius: 12,
+    padding: 16,
+    backgroundColor: '#edf2f7',
+  },
+  resultLabel: {
+    fontSize: 12,
+    color: '#4a5568',
+    textTransform: 'uppercase',
+  },
+  resultValue: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  error: {
+    color: '#e53e3e',
+  },
+});

--- a/shared/api/simulator.ts
+++ b/shared/api/simulator.ts
@@ -1,0 +1,46 @@
+export interface SimulationInput {
+  monthlyIncome: number;
+  monthlyExpenses: number;
+  investmentRate: number;
+}
+
+export interface SimulationResult {
+  monthlySavings: number;
+  annualSavings: number;
+  investmentReturn: number;
+}
+
+const DEFAULT_HEADERS: HeadersInit = {
+  'Content-Type': 'application/json',
+};
+
+export async function simulateFinancialPlan(
+  endpoint: string,
+  input: SimulationInput,
+  signal?: AbortSignal,
+): Promise<SimulationResult> {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: DEFAULT_HEADERS,
+    body: JSON.stringify(input),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Falha ao calcular simulação: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export function buildFallbackResult(input: SimulationInput): SimulationResult {
+  const monthlySavings = Math.max(input.monthlyIncome - input.monthlyExpenses, 0);
+  const annualSavings = monthlySavings * 12;
+  const investmentReturn = annualSavings * input.investmentRate;
+
+  return {
+    monthlySavings,
+    annualSavings,
+    investmentReturn,
+  };
+}

--- a/web/src/components/Simulator.tsx
+++ b/web/src/components/Simulator.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState, type ChangeEvent } from 'react';
+import type { SimulationInput, SimulationResult } from '../../../shared/api/simulator';
+import { buildFallbackResult, simulateFinancialPlan } from '../../../shared/api/simulator';
+
+const DEBOUNCE_DELAY = 300;
+const API_ENDPOINT = '/api/simulator';
+
+const initialState: SimulationInput = {
+  monthlyIncome: 30000,
+  monthlyExpenses: 18000,
+  investmentRate: 0.1,
+};
+
+export function Simulator() {
+  const [form, setForm] = useState<SimulationInput>(initialState);
+  const [result, setResult] = useState<SimulationResult>(buildFallbackResult(initialState));
+  const [isCalculating, setIsCalculating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    setIsCalculating(true);
+    setError(null);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(async () => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+
+      const abortController = new AbortController();
+      abortRef.current = abortController;
+
+      try {
+        const data = await simulateFinancialPlan(API_ENDPOINT, form, abortController.signal);
+        setResult(data);
+      } catch (err) {
+        console.error(err);
+        setResult(buildFallbackResult(form));
+        setError('Não foi possível atualizar a simulação em tempo real. Exibindo cálculo estimado.');
+      } finally {
+        setIsCalculating(false);
+      }
+    }, DEBOUNCE_DELAY);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+    };
+  }, [form]);
+
+  function handleInputChange(event: ChangeEvent<HTMLInputElement>) {
+    const { name, value } = event.target;
+    setForm((previous) => ({
+      ...previous,
+      [name]: Number(value),
+    }));
+  }
+
+  return (
+    <section aria-live="polite">
+      <header>
+        <h1>Simulador financeiro</h1>
+        <p>Ajuste os valores e veja o resultado recalculado automaticamente.</p>
+      </header>
+
+      <form className="simulator-form">
+        <label>
+          Renda mensal
+          <input
+            name="monthlyIncome"
+            type="number"
+            min={0}
+            value={form.monthlyIncome}
+            onChange={handleInputChange}
+          />
+        </label>
+
+        <label>
+          Despesas mensais
+          <input
+            name="monthlyExpenses"
+            type="number"
+            min={0}
+            value={form.monthlyExpenses}
+            onChange={handleInputChange}
+          />
+        </label>
+
+        <label>
+          Taxa de investimento anual
+          <input
+            name="investmentRate"
+            type="number"
+            min={0}
+            step={0.01}
+            value={form.investmentRate}
+            onChange={handleInputChange}
+          />
+        </label>
+      </form>
+
+      {isCalculating ? (
+        <p role="status" className="simulator-spinner">
+          calculando...
+        </p>
+      ) : (
+        <dl className="simulator-result">
+          <div>
+            <dt>Poupança mensal</dt>
+            <dd>{result.monthlySavings.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</dd>
+          </div>
+          <div>
+            <dt>Poupança anual</dt>
+            <dd>{result.annualSavings.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</dd>
+          </div>
+          <div>
+            <dt>Retorno do investimento</dt>
+            <dd>
+              {result.investmentReturn.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+            </dd>
+          </div>
+        </dl>
+      )}
+
+      {error ? <p className="simulator-error">{error}</p> : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared simulator API helper with fallback client-side math
- update the web simulator component to debounce input changes and show a loading state
- implement the mobile simulator screen with the same real-time recalculation UX

## Testing
- not run (project scaffolding only)

------
https://chatgpt.com/codex/tasks/task_e_68dd5f2a3828832281e03dc2a07f0e0f