### PR TITLE
chore: configure automated changelog generation

### DIFF
--- a/.auto-changelog
+++ b/.auto-changelog
@@ -1,0 +1,12 @@
+{
+  "output": "CHANGELOG.md",
+  "template": "keepachangelog",
+  "unreleased": true,
+  "commitLimit": false,
+  "hideCredit": true,
+  "sortCommits": "date-desc",
+  "github": {
+    "owner": "andresenagg-ux",
+    "repo": "MedFinance"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Merged
+
+- docs: add release notes for v0.2.0 
+- Add CLI financial simulator workspace 
+- Add Swagger documentation for MedFinance API 
+- feat: enable real-time simulation recalculation 
+- Add consolidated CI workflow for workspace checks 
+- feat: add finance simulator screen 
+- Add finance simulator React component 
+- feat: add structured logging with Winston 
+- Add D3-powered financial dashboard 
+- Configure git attributes for text and binary assets 
+- Configure Git LFS for binary assets 
+- Add npm workspace scripts for MedFinance monorepo 
+- Resolve gitignore conflict by combining ignore entries 
+- Align gitignore with current project structure 
+- fix(frontend-web): resolve styles.css merge conflict 
+- Configure Tailwind design tokens for web frontend 
+- fix: include react types in dependencies 
+- Fix frontend build tsconfig type references 
+- Update gitignore entries 
+- Add monorepo scaffolding with tests and CI pipeline 
+- Add Docker Compose setup for MedFinance services 
+- Resolve merge conflict in Expo App.js 
+- Resolve README merge conflict 
+- Resolve README merge conflict 
+- Resolve backend package.json merge conflict 
+- Initialize Finanças Médicas project structure 
+
+### Commits
+
+- feat(cli): add financial simulator cli and tests 
+- feat(backend): add swagger documentation 
+- feat: add real-time simulators 
+- chore(ci): unify workspace checks in CI 
+- Add finance simulator component with D3 visualization 
+- feat(backend): add structured logging with winston 
+- feat(frontend-web): add D3 financial dashboard 
+- Configure repository git attributes 
+- chore: add npm workspace management 
+- Resolve gitignore merge conflict 
+- chore(frontend-web): configure tailwind design tokens 
+- fix: include react type packages in dependencies 
+- Add monorepo scaffolding with tests and CI 
+- Add Docker setup for backend, frontend, and database 
+- Resolve Expo App.js merge conflict 
+- Initial commit 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ O repositório utiliza workspaces do npm para facilitar comandos que englobam to
 ```bash
 npm test      # executa os testes de backend, frontend web e mobile
 npm run build # compila backend e frontend web
+npm run changelog # gera CHANGELOG.md agregando commits no formato Keep a Changelog
 ```
 
 Para desenvolver localmente, execute os scripts `npm run dev` em cada workspace individualmente.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,10 @@
         "frontend-web",
         "frontend-mobile",
         "cli"
-      ]
+      ],
+      "devDependencies": {
+        "auto-changelog": "^2.5.0"
+      }
     },
     "backend": {
       "name": "medfinance-backend",
@@ -8448,40 +8451,6 @@
         "node": ">= 0.10.5"
       }
     },
-    "frontend-mobile/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "frontend-mobile/node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
-    "frontend-mobile/node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "frontend-mobile/node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "frontend-mobile/node_modules/node-forge": {
       "version": "1.3.1",
       "license": "(BSD-3-Clause OR GPL-2.0)",
@@ -15433,6 +15402,40 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
+    "node_modules/auto-changelog": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.5.0.tgz",
+      "integrity": "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "handlebars": "^4.7.7",
+        "import-cwd": "^3.0.0",
+        "node-fetch": "^2.6.1",
+        "parse-github-url": "^1.0.3",
+        "semver": "^7.3.5"
+      },
+      "bin": {
+        "auto-changelog": "src/index.js"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/auto-changelog/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -17121,6 +17124,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -18321,6 +18350,26 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -18464,6 +18513,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-github-url": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
+      "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "parse-github-url": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/parse-json": {
@@ -19260,6 +19322,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -19630,6 +19698,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "dev": "echo 'Execute os servidores individuais com npm run dev em cada workspace.'",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
-    "ci": "npm run test && npm run build"
+    "ci": "npm run test && npm run build",
+    "changelog": "auto-changelog --commit-limit false --sort-commits date-desc"
+  },
+  "devDependencies": {
+    "auto-changelog": "^2.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- add the auto-changelog dev dependency and npm script to generate the changelog
- configure auto-changelog defaults and check the generated CHANGELOG.md into the repo
- document the changelog command in the global scripts section of the README

## Testing
- npm run changelog

------
https://chatgpt.com/codex/tasks/task_e_68e314c90a9c83228ffe9f68f54313a5