### PR TITLE
Configure Dependabot for npm projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "daily"
+    security-updates: true
+  - package-ecosystem: "npm"
+    directory: "/frontend-web"
+    schedule:
+      interval: "daily"
+    security-updates: true
+  - package-ecosystem: "npm"
+    directory: "/frontend-mobile"
+    schedule:
+      interval: "daily"
+    security-updates: true


### PR DESCRIPTION
## Summary
- add Dependabot configuration to monitor npm dependencies in backend, frontend-web, and frontend-mobile directories
- schedule daily checks with automatic security updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd66d298c083229d0a3a6fa0b9f285