### PR TITLE
Add CDI rate endpoint for investment projections

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import { swaggerDocument } from './config/swagger';
 import swaggerUi from 'swagger-ui-express';
 import { requestLogger } from './middlewares/requestLogger';
 import { router as userRouter } from './routes/users';
+import { router as investmentRouter } from './routes/investments';
 
 export function createApp() {
   const app = express();
@@ -29,6 +30,7 @@ export function createApp() {
   });
 
   app.use('/users', userRouter);
+  app.use('/investments', investmentRouter);
 
   app.use((req, res) => {
     const message = `Route ${req.method} ${req.path} not found`;

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -23,6 +23,10 @@ export const swaggerDocument = {
       name: 'Users',
       description: 'Endpoints that manage or retrieve user information.',
     },
+    {
+      name: 'Investments',
+      description: 'Endpoints that provide investment-related information.',
+    },
   ],
   paths: {
     '/healthcheck': {
@@ -72,6 +76,109 @@ export const swaggerDocument = {
                       items: {
                         $ref: '#/components/schemas/User',
                       },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/investments/cdi': {
+      get: {
+        tags: ['Investments'],
+        summary: 'Retrieves the latest CDI rate.',
+        description:
+          'Fetches the most recent CDI (Certificado de Depósito Interbancário) annual rate published by the Banco Central do Brasil and, optionally, estimates the profit of an investment held for one year.',
+        parameters: [
+          {
+            in: 'query',
+            name: 'amount',
+            description: 'Investment amount in BRL used to project the profit after one year at the current CDI rate.',
+            required: false,
+            schema: {
+              type: 'number',
+              example: 10000,
+              minimum: 0,
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Latest CDI rate and optional investment projection.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['date', 'annualRate'],
+                  properties: {
+                    date: {
+                      type: 'string',
+                      format: 'date',
+                      description: 'Date of the CDI rate informed by Banco Central do Brasil.',
+                      example: '2025-10-03',
+                    },
+                    annualRate: {
+                      type: 'number',
+                      description: 'Annual CDI rate percentage.',
+                      example: 13.65,
+                    },
+                    investmentProjection: {
+                      type: 'object',
+                      description: 'Projection for an investment kept for one year using the CDI rate.',
+                      required: ['principal', 'profitAfterOneYear', 'finalAmountAfterOneYear'],
+                      properties: {
+                        principal: {
+                          type: 'number',
+                          description: 'Amount invested in BRL.',
+                          example: 10000,
+                        },
+                        profitAfterOneYear: {
+                          type: 'number',
+                          description: 'Estimated profit after one year in BRL.',
+                          example: 1365,
+                        },
+                        finalAmountAfterOneYear: {
+                          type: 'number',
+                          description: 'Projected total amount after one year in BRL.',
+                          example: 11365,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Validation error for the provided query parameters.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['message'],
+                  properties: {
+                    message: {
+                      type: 'string',
+                      example: 'The "amount" query parameter must be a positive number.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '502': {
+            description: 'Error returned when the API cannot communicate with Banco Central do Brasil.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['message'],
+                  properties: {
+                    message: {
+                      type: 'string',
+                      example: 'Unable to retrieve CDI rate from Banco Central do Brasil.',
                     },
                   },
                 },

--- a/backend/src/controllers/investmentController.ts
+++ b/backend/src/controllers/investmentController.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from 'express';
+import { logger } from '../config/logger';
+import { cdiService } from '../services/cdiService';
+
+export async function getCdiQuote(req: Request, res: Response) {
+  try {
+    const amountParam = req.query.amount;
+    const investmentAmount =
+      amountParam !== undefined && amountParam !== '' ? Number(amountParam) : undefined;
+
+    if (amountParam !== undefined && (investmentAmount === undefined || Number.isNaN(investmentAmount) || investmentAmount <= 0)) {
+      res.status(400).json({ message: 'The "amount" query parameter must be a positive number.' });
+      return;
+    }
+
+    const { date, rate } = await cdiService.getLatestRate();
+
+    logger.debug('Fetched latest CDI rate', { date, rate });
+
+    const response: {
+      date: string;
+      annualRate: number;
+      investmentProjection?: {
+        principal: number;
+        profitAfterOneYear: number;
+        finalAmountAfterOneYear: number;
+      };
+    } = {
+      date,
+      annualRate: rate,
+    };
+
+    if (investmentAmount !== undefined) {
+      const profit = investmentAmount * (rate / 100);
+      response.investmentProjection = {
+        principal: investmentAmount,
+        profitAfterOneYear: Number(profit.toFixed(2)),
+        finalAmountAfterOneYear: Number((investmentAmount + profit).toFixed(2)),
+      };
+    }
+
+    res.json(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error while fetching CDI rate';
+    logger.error('Failed to retrieve the CDI rate', { message });
+    res.status(502).json({ message: 'Unable to retrieve CDI rate from Banco Central do Brasil.' });
+  }
+}

--- a/backend/src/routes/investments.ts
+++ b/backend/src/routes/investments.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { getCdiQuote } from '../controllers/investmentController';
+
+export const router = Router();
+
+router.get('/cdi', getCdiQuote);

--- a/backend/src/services/cdiService.ts
+++ b/backend/src/services/cdiService.ts
@@ -1,0 +1,78 @@
+import https from 'https';
+
+export interface CdiQuote {
+  /**
+   * Date of the CDI rate in ISO-8601 format (YYYY-MM-DD).
+   */
+  date: string;
+  /**
+   * Annual CDI rate expressed as a percentage (e.g., 13.65 for 13.65%).
+   */
+  rate: number;
+}
+
+class CdiService {
+  private readonly endpoint =
+    'https://api.bcb.gov.br/dados/serie/bcdata.sgs.4389/dados/ultimos/1?formato=json';
+
+  async getLatestRate(): Promise<CdiQuote> {
+    const response = await this.fetchBancoCentralData<{ data: string; valor: string }[]>(this.endpoint);
+
+    if (!Array.isArray(response) || response.length === 0) {
+      throw new Error('Banco Central do Brasil returned an empty response for the CDI rate.');
+    }
+
+    const [latest] = response;
+    const rate = Number(latest.valor.replace(',', '.'));
+
+    if (Number.isNaN(rate)) {
+      throw new Error('Banco Central do Brasil returned an invalid CDI rate.');
+    }
+
+    const [day, month, year] = latest.data.split('/');
+
+    if (!day || !month || !year) {
+      throw new Error('Banco Central do Brasil returned an invalid date for the CDI rate.');
+    }
+
+    const date = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+
+    return { date, rate };
+  }
+
+  private fetchBancoCentralData<T>(url: string): Promise<T> {
+    return new Promise((resolve, reject) => {
+      https
+        .get(url, (res) => {
+          const { statusCode } = res;
+
+          if (!statusCode || statusCode < 200 || statusCode >= 300) {
+            res.resume();
+            reject(new Error(`Failed to fetch CDI rate from Banco Central do Brasil (status ${statusCode ?? 'unknown'}).`));
+            return;
+          }
+
+          let rawData = '';
+          res.setEncoding('utf8');
+
+          res.on('data', (chunk) => {
+            rawData += chunk;
+          });
+
+          res.on('end', () => {
+            try {
+              const parsed = JSON.parse(rawData) as T;
+              resolve(parsed);
+            } catch (error) {
+              reject(new Error('Failed to parse response from Banco Central do Brasil.'));
+            }
+          });
+        })
+        .on('error', (error) => {
+          reject(new Error(`Unable to connect to Banco Central do Brasil: ${(error as Error).message}`));
+        });
+    });
+  }
+}
+
+export const cdiService = new CdiService();

--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -1,8 +1,20 @@
 import request from 'supertest';
 import { createApp } from '../src/app';
+import { cdiService } from '../src/services/cdiService';
+
+jest.mock('../src/services/cdiService', () => ({
+  cdiService: {
+    getLatestRate: jest.fn(),
+  },
+}));
 
 describe('MedFinance API', () => {
   const app = createApp();
+  const mockedCdiService = cdiService as jest.Mocked<typeof cdiService>;
+
+  beforeEach(() => {
+    mockedCdiService.getLatestRate.mockReset();
+  });
 
   it('returns ok on /healthcheck', async () => {
     const response = await request(app).get('/healthcheck');
@@ -33,7 +45,36 @@ describe('MedFinance API', () => {
       paths: expect.objectContaining({
         '/users': expect.any(Object),
         '/healthcheck': expect.any(Object),
+        '/investments/cdi': expect.any(Object),
       }),
     });
+  });
+
+  it('provides the latest CDI rate and investment projection', async () => {
+    mockedCdiService.getLatestRate.mockResolvedValue({ date: '2025-10-03', rate: 13.65 });
+
+    const response = await request(app).get('/investments/cdi').query({ amount: 10000 });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      date: '2025-10-03',
+      annualRate: 13.65,
+      investmentProjection: {
+        principal: 10000,
+        profitAfterOneYear: 1365,
+        finalAmountAfterOneYear: 11365,
+      },
+    });
+    expect(mockedCdiService.getLatestRate).toHaveBeenCalledTimes(1);
+  });
+
+  it('validates the investment amount parameter', async () => {
+    const response = await request(app).get('/investments/cdi').query({ amount: '-50' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: 'The "amount" query parameter must be a positive number.',
+    });
+    expect(mockedCdiService.getLatestRate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a CDI service that retrieves the latest rate from Banco Central do Brasil
- expose an /investments/cdi endpoint with optional one-year profit projection
- document the endpoint in Swagger and extend automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3b37549748322b0a525de0dded17d