### PR TITLE
feat(frontend-web): add modern courses page

### DIFF
--- a/frontend-web/src/App.tsx
+++ b/frontend-web/src/App.tsx
@@ -1,6 +1,7 @@
 import Hero from './components/Hero';
 import FeatureGrid from './components/FeatureGrid';
 import FinancialDashboard from './components/FinancialDashboard';
+import CoursesPage from './components/CoursesPage';
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Hero />
       <FeatureGrid />
       <FinancialDashboard />
+      <CoursesPage />
     </div>
   );
 }

--- a/frontend-web/src/components/CoursesPage.tsx
+++ b/frontend-web/src/components/CoursesPage.tsx
@@ -1,0 +1,228 @@
+import type { FC } from 'react';
+
+const courseHighlights = [
+  { label: 'Horas de conteúdo', value: '120h +' },
+  { label: 'Planilhas e modelos', value: '30 ferramentas' },
+  { label: 'Mentorias coletivas', value: '2x por mês' }
+];
+
+const learningPaths = [
+  {
+    title: 'Fundamentos financeiros',
+    description:
+      'Entenda os pilares da organização financeira pessoal, fluxo de caixa e criação de metas para profissionais da saúde.',
+    focus: ['Orçamento inteligente', 'Reserva de emergência', 'Hábitos financeiros']
+  },
+  {
+    title: 'Investimentos para médicos',
+    description:
+      'Construa uma carteira diversificada com foco em renda passiva e proteção patrimonial para diferentes estágios da carreira.',
+    focus: ['Renda fixa e variável', 'Previdência privada', 'Planejamento sucessório']
+  },
+  {
+    title: 'Gestão de consultório',
+    description:
+      'Otimize receitas, controle custos e aprenda a precificar procedimentos de forma sustentável.',
+    focus: ['Precificação', 'Fluxo de caixa', 'Indicadores de performance']
+  }
+];
+
+const courseCatalog = [
+  {
+    title: 'Planejamento Financeiro 360°',
+    description:
+      'Crie um plano financeiro completo que equilibra qualidade de vida, investimentos e expansão do consultório.',
+    duration: '6 semanas',
+    level: 'Intermediário',
+    format: 'Trilha guiada',
+    topics: ['Mapa de metas', 'Análise de gastos', 'Projeções personalizadas']
+  },
+  {
+    title: 'Investimentos em Saúde',
+    description:
+      'Aprenda a investir com segurança utilizando estratégias alinhadas às metas da carreira médica.',
+    duration: '4 semanas',
+    level: 'Avançado',
+    format: 'Curso imersivo',
+    topics: ['Perfil de risco', 'Carteira antifrágil', 'Proteção patrimonial']
+  },
+  {
+    title: 'Consultório Rentável',
+    description:
+      'Implemente uma operação enxuta, com indicadores que te ajudam a tomar decisões rápidas e baseadas em dados.',
+    duration: '8 semanas',
+    level: 'Intermediário',
+    format: 'Programa híbrido',
+    topics: ['Diagnóstico financeiro', 'Fluxo operacional', 'KPIs essenciais']
+  }
+];
+
+const mentors = [
+  {
+    name: 'Dra. Ana Luísa Prado',
+    role: 'Médica e educadora financeira',
+    bio: 'Especialista em orientar profissionais da saúde em transições de carreira com foco em finanças pessoais.'
+  },
+  {
+    name: 'Ricardo Fernandes',
+    role: 'Planejador financeiro CFP®',
+    bio: 'Mais de 12 anos construindo estratégias patrimoniais para clínicas e consultórios de alto padrão.'
+  },
+  {
+    name: 'Larissa Monteiro',
+    role: 'Analista de investimentos',
+    bio: 'Responsável por curadoria de carteiras e análises de risco para profissionais da saúde autônomos.'
+  }
+];
+
+const CoursesPage: FC = () => (
+  <main className="courses">
+    <section className="courses__hero">
+      <div className="container">
+        <div className="courses__hero-content">
+          <span className="courses__eyebrow">Trilhas especializadas</span>
+          <h1>Conquiste segurança financeira com cursos pensados para sua rotina médica</h1>
+          <p>
+            Conecte-se a um ecossistema de aprendizado contínuo, com aulas ao vivo, simuladores interativos e modelos
+            prontos para aplicar no seu consultório.
+          </p>
+          <form className="courses__search" role="search">
+            <label className="sr-only" htmlFor="search-courses">
+              Buscar cursos
+            </label>
+            <input id="search-courses" type="search" placeholder="Buscar módulos, temas ou mentores" />
+            <button type="submit">Explorar trilhas</button>
+          </form>
+          <dl className="courses__highlights">
+            {courseHighlights.map((highlight) => (
+              <div key={highlight.label}>
+                <dt>{highlight.value}</dt>
+                <dd>{highlight.label}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+    </section>
+
+    <section className="courses__section" aria-labelledby="paths-heading">
+      <div className="container">
+        <div className="courses__section-header">
+          <div>
+            <h2 id="paths-heading">Escolha a trilha ideal para o seu momento</h2>
+            <p>
+              Selecione o foco que melhor se adapta à sua jornada profissional. Combine trilhas, participe de mentorias
+              coletivas e acesse planos de ação personalizados.
+            </p>
+          </div>
+          <a className="courses__link" href="#catalogo">
+            Ver calendário completo
+          </a>
+        </div>
+        <div className="courses__paths">
+          {learningPaths.map((path) => (
+            <article key={path.title} className="courses__path-card">
+              <h3>{path.title}</h3>
+              <p>{path.description}</p>
+              <ul>
+                {path.focus.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section className="courses__section" aria-labelledby="catalog-heading" id="catalogo">
+      <div className="container">
+        <div className="courses__section-header">
+          <div>
+            <h2 id="catalog-heading">Catálogo de cursos</h2>
+            <p>
+              Conteúdos modulares, com certificado de conclusão e acompanhamento direto do nosso time de especialistas.
+            </p>
+          </div>
+          <div className="courses__filters">
+            <button type="button">Todos os níveis</button>
+            <button type="button">Ao vivo</button>
+            <button type="button">On-demand</button>
+          </div>
+        </div>
+        <div className="courses__grid">
+          {courseCatalog.map((course) => (
+            <article key={course.title} className="course-card">
+              <header>
+                <span className="course-card__badge">{course.format}</span>
+                <span className="course-card__level">{course.level}</span>
+              </header>
+              <h3>{course.title}</h3>
+              <p>{course.description}</p>
+              <ul>
+                {course.topics.map((topic) => (
+                  <li key={topic}>{topic}</li>
+                ))}
+              </ul>
+              <footer>
+                <span>{course.duration}</span>
+                <button type="button">Detalhes do curso</button>
+              </footer>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section className="courses__section courses__section--alt" aria-labelledby="mentors-heading">
+      <div className="container">
+        <div className="courses__section-header">
+          <div>
+            <h2 id="mentors-heading">Mentores que conhecem a realidade da saúde</h2>
+            <p>
+              Encontros ao vivo, feedback contínuo e acompanhamento individualizado para acelerar os resultados do seu
+              planejamento financeiro.
+            </p>
+          </div>
+          <a className="courses__link" href="#">
+            Conheça todos os mentores
+          </a>
+        </div>
+        <div className="courses__mentors">
+          {mentors.map((mentor) => (
+            <article key={mentor.name} className="courses__mentor-card">
+              <div>
+                <strong>{mentor.name}</strong>
+                <span>{mentor.role}</span>
+              </div>
+              <p>{mentor.bio}</p>
+              <button type="button">Agendar conversa</button>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section className="courses__cta" aria-labelledby="cta-heading">
+      <div className="container">
+        <div className="courses__cta-content">
+          <h2 id="cta-heading">Pronto para assumir o controle das suas finanças?</h2>
+          <p>
+            Garanta acesso imediato às trilhas, participe da comunidade exclusiva e receba o mapa financeiro adaptado à
+            sua realidade.
+          </p>
+          <div className="courses__cta-actions">
+            <button type="button" className="courses__cta-primary">
+              Começar agora
+            </button>
+            <button type="button" className="courses__cta-secondary">
+              Conversar com um especialista
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+);
+
+export default CoursesPage;

--- a/frontend-web/src/styles.css
+++ b/frontend-web/src/styles.css
@@ -30,6 +30,18 @@
     @apply flex flex-col gap-12;
   }
 
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   .container {
     width: min(960px, 100%);
     @apply mx-auto px-6;
@@ -231,5 +243,449 @@
     font-size: clamp(1.4rem, 2vw, 1.7rem);
     font-weight: 600;
     color: rgb(var(--color-gray-900) / 1);
+  }
+
+  .courses {
+    display: flex;
+    flex-direction: column;
+    gap: 5rem;
+    padding-bottom: 6rem;
+  }
+
+  .courses__hero {
+    background: radial-gradient(circle at top left, rgb(var(--color-brand-200) / 1), rgb(var(--color-brand-600) / 1));
+    color: white;
+    padding-top: 5rem;
+    padding-bottom: 6rem;
+  }
+
+  .courses__hero-content {
+    display: grid;
+    gap: 1.5rem;
+    max-width: 720px;
+  }
+
+  .courses__eyebrow {
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  .courses__hero h1 {
+    font-size: clamp(2.5rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0;
+  }
+
+  .courses__hero p {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    margin: 0;
+    color: rgb(var(--color-gray-100) / 0.9);
+  }
+
+  .courses__search {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: var(--radius-xl);
+    padding: 0.75rem;
+    backdrop-filter: blur(12px);
+  }
+
+  .courses__search input {
+    flex: 1 1 220px;
+    min-width: 0;
+    border: none;
+    border-radius: var(--radius-lg);
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    background: rgba(255, 255, 255, 0.9);
+    color: rgb(var(--color-gray-900) / 1);
+  }
+
+  .courses__search input::placeholder {
+    color: rgb(var(--color-gray-500) / 1);
+  }
+
+  .courses__search button {
+    border: none;
+    border-radius: var(--radius-lg);
+    padding: 0.75rem 1.5rem;
+    font-weight: 600;
+    font-size: 1rem;
+    background: rgb(var(--color-gray-900) / 0.95);
+    color: white;
+    cursor: pointer;
+    transition: transform 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out);
+  }
+
+  .courses__search button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+  }
+
+  .courses__highlights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin: 0;
+  }
+
+  .courses__highlights div {
+    background: rgba(15, 23, 42, 0.24);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.5rem;
+    backdrop-filter: blur(8px);
+  }
+
+  .courses__highlights dt {
+    font-size: 1.4rem;
+    font-weight: 700;
+  }
+
+  .courses__highlights dd {
+    margin: 0.25rem 0 0;
+    font-size: 0.95rem;
+    color: rgb(var(--color-gray-200) / 1);
+  }
+
+  .courses__section {
+    padding-top: 2.5rem;
+  }
+
+  .courses__section--alt {
+    background: rgb(var(--color-gray-50) / 1);
+    padding: 4rem 0;
+  }
+
+  .courses__section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 2.5rem;
+  }
+
+  @media (min-width: 960px) {
+    .courses__section-header {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+
+  .courses__section-header h2 {
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    margin: 0 0 0.75rem;
+  }
+
+  .courses__section-header p {
+    margin: 0;
+    max-width: 60ch;
+    line-height: 1.7;
+    color: rgb(var(--color-gray-600) / 1);
+  }
+
+  .courses__link {
+    text-decoration: none;
+    font-weight: 600;
+    color: rgb(var(--color-brand-700) / 1);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .courses__link::after {
+    content: '→';
+    font-size: 1.1rem;
+  }
+
+  .courses__paths {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 960px) {
+    .courses__paths {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .courses__path-card {
+    background: white;
+    border-radius: var(--radius-2xl);
+    padding: 2rem;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgb(var(--color-gray-200) / 0.6);
+    display: grid;
+    gap: 1rem;
+  }
+
+  .courses__path-card h3 {
+    margin: 0;
+    font-size: 1.35rem;
+  }
+
+  .courses__path-card p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.65;
+  }
+
+  .courses__path-card ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .courses__path-card li {
+    background: rgb(var(--color-brand-100) / 0.8);
+    color: rgb(var(--color-brand-800) / 1);
+    border-radius: 9999px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+
+  .courses__filters {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .courses__filters button {
+    border: 1px solid rgb(var(--color-gray-300) / 1);
+    background: white;
+    color: rgb(var(--color-gray-700) / 1);
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s var(--ease-out);
+  }
+
+  .courses__filters button:hover {
+    border-color: rgb(var(--color-brand-500) / 1);
+    color: rgb(var(--color-brand-600) / 1);
+  }
+
+  .courses__grid {
+    display: grid;
+    gap: 1.75rem;
+  }
+
+  @media (min-width: 960px) {
+    .courses__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .course-card {
+    position: relative;
+    display: grid;
+    gap: 1rem;
+    padding: 2rem;
+    border-radius: var(--radius-2xl);
+    background: white;
+    border: 1px solid rgb(var(--color-gray-200) / 0.6);
+    box-shadow: 0 20px 36px rgba(15, 23, 42, 0.08);
+  }
+
+  .course-card header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .course-card__badge,
+  .course-card__level {
+    font-size: 0.85rem;
+    font-weight: 600;
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+  }
+
+  .course-card__badge {
+    background: rgb(var(--color-brand-100) / 1);
+    color: rgb(var(--color-brand-800) / 1);
+  }
+
+  .course-card__level {
+    background: rgb(var(--color-gray-900) / 1);
+    color: white;
+  }
+
+  .course-card h3 {
+    margin: 0;
+    font-size: 1.45rem;
+  }
+
+  .course-card p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.7;
+  }
+
+  .course-card ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 0.5rem;
+    color: rgb(var(--color-gray-700) / 1);
+  }
+
+  .course-card footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .course-card footer span {
+    font-weight: 600;
+    color: rgb(var(--color-brand-700) / 1);
+  }
+
+  .course-card footer button {
+    border: none;
+    background: rgb(var(--color-brand-600) / 1);
+    color: white;
+    font-weight: 600;
+    border-radius: var(--radius-lg);
+    padding: 0.5rem 1.25rem;
+    cursor: pointer;
+    transition: transform 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out);
+  }
+
+  .course-card footer button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 30px rgba(30, 64, 175, 0.25);
+  }
+
+  .courses__mentors {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 960px) {
+    .courses__mentors {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .courses__mentor-card {
+    background: white;
+    border-radius: var(--radius-2xl);
+    padding: 2rem;
+    border: 1px solid rgb(var(--color-gray-200) / 0.6);
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 1rem;
+  }
+
+  .courses__mentor-card strong {
+    font-size: 1.15rem;
+  }
+
+  .courses__mentor-card span {
+    display: block;
+    color: rgb(var(--color-gray-500) / 1);
+    margin-top: 0.25rem;
+  }
+
+  .courses__mentor-card p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.7;
+  }
+
+  .courses__mentor-card button {
+    justify-self: start;
+    border: none;
+    background: rgb(var(--color-gray-900) / 1);
+    color: white;
+    font-weight: 600;
+    border-radius: var(--radius-lg);
+    padding: 0.5rem 1.25rem;
+    cursor: pointer;
+    transition: transform 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out);
+  }
+
+  .courses__mentor-card button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.25);
+  }
+
+  .courses__cta {
+    background: linear-gradient(135deg, rgb(var(--color-brand-600) / 1), rgb(var(--color-brand-400) / 1));
+    color: white;
+    padding: 4rem 0;
+  }
+
+  .courses__cta-content {
+    max-width: 720px;
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .courses__cta-content h2 {
+    margin: 0;
+    font-size: clamp(2.25rem, 5vw, 3rem);
+  }
+
+  .courses__cta-content p {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: rgb(var(--color-gray-100) / 0.9);
+  }
+
+  .courses__cta-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .courses__cta-primary,
+  .courses__cta-secondary {
+    border-radius: var(--radius-full);
+    padding: 0.75rem 1.75rem;
+    font-weight: 700;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out);
+  }
+
+  .courses__cta-primary {
+    background: white;
+    color: rgb(var(--color-brand-700) / 1);
+  }
+
+  .courses__cta-secondary {
+    background: rgba(15, 23, 42, 0.25);
+    color: white;
+  }
+
+  .courses__cta-primary:hover,
+  .courses__cta-secondary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.2);
+  }
+
+  @media (max-width: 640px) {
+    .course-card footer {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .courses__hero {
+      padding-top: 5rem;
+    }
   }
 }

--- a/frontend-web/src/styles/tokens.css
+++ b/frontend-web/src/styles/tokens.css
@@ -69,6 +69,7 @@
   --radius-lg: 12px;
   --radius-xl: 16px;
   --radius-2xl: 24px;
+  --radius-full: 9999px;
 
   --ease-in: cubic-bezier(0.4, 0, 1, 1);
   --ease-out: cubic-bezier(0, 0, 0.2, 1);

--- a/frontend-web/src/vite-env.d.ts
+++ b/frontend-web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add a dedicated CoursesPage with hero, learning paths, catalog, mentors, and CTA sections
- expand shared styles with accessibility helper, modern course layout styling, and new radius token
- wire the new page into the app shell and include Vite client typings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3be1edc488322858695d085b979b4