### PR TITLE
feat(frontend-web): add modern courses experience

### DIFF
--- a/frontend-web/src/App.tsx
+++ b/frontend-web/src/App.tsx
@@ -1,17 +1,7 @@
-import Hero from './components/Hero';
-import FeatureGrid from './components/FeatureGrid';
-import FinancialDashboard from './components/FinancialDashboard';
-import InvestmentPlanner from './components/InvestmentPlanner';
+import CoursesPage from './pages/CoursesPage';
 
 function App() {
-  return (
-    <div className="app">
-      <Hero />
-      <FeatureGrid />
-      <FinancialDashboard />
-      <InvestmentPlanner />
-    </div>
-  );
+  return <CoursesPage />;
 }
 
 export default App;

--- a/frontend-web/src/__tests__/App.test.tsx
+++ b/frontend-web/src/__tests__/App.test.tsx
@@ -1,27 +1,48 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from '../App';
 
-describe('App', () => {
-  it('renders hero copy', () => {
+describe('Cursos MedFinance', () => {
+  it('exibe o herói da página de cursos com ações principais', () => {
     render(<App />);
 
-    expect(screen.getByRole('heading', { name: 'MedFinance' })).toBeInTheDocument();
-    expect(screen.getByText(/organizar suas finanças pessoais/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: /cursos medfinance/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /transforme sua relação com finanças, investimentos e gestão de carreira médica/i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /ver trilhas disponíveis/i })).toHaveAttribute('href', '#cursos');
   });
 
-  it('lists feature highlights', () => {
+  it('lista os cursos em destaque por padrão', () => {
     render(<App />);
 
-    const cards = screen.getAllByRole('heading', { level: 3 });
-    expect(cards).toHaveLength(3);
+    expect(
+      screen.getByRole('article', {
+        name: /estratégias financeiras para clínicas e consultórios/i
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('article', { name: /fundamentos de finanças pessoais para residentes/i })
+    ).toBeInTheDocument();
   });
 
-  it('renders the financial dashboard with key metrics', () => {
+  it('filtra cursos quando uma trilha é selecionada', async () => {
+    const user = userEvent.setup();
     render(<App />);
 
-    expect(screen.getByRole('heading', { level: 2, name: /dashboard financeiro/i })).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /evolução das receitas e despesas mensais/i })).toBeInTheDocument();
-    expect(screen.getByText(/Receita acumulada/i)).toBeInTheDocument();
-    expect(screen.getByText(/Lucro líquido/i)).toBeInTheDocument();
+    await act(async () => {
+      await user.click(screen.getByRole('tab', { name: /investimentos médicos/i }));
+    });
+
+    const courseRegion = screen.getByRole('region', { name: /cursos em destaque/i });
+
+    await waitFor(() => {
+      const filteredCourses = within(courseRegion).getAllByRole('article');
+      expect(filteredCourses).toHaveLength(2);
+      expect(filteredCourses[0]).toHaveAccessibleName(/investimentos e proteção de patrimônio médico/i);
+      expect(filteredCourses[1]).toHaveAccessibleName(/fundamentos de finanças pessoais para residentes/i);
+    });
   });
 });

--- a/frontend-web/src/pages/CoursesPage.tsx
+++ b/frontend-web/src/pages/CoursesPage.tsx
@@ -1,0 +1,415 @@
+import { useMemo, useState } from 'react';
+
+const numberFormatter = new Intl.NumberFormat('pt-BR');
+
+type TrackId = 'all' | 'financas-clinicas' | 'investimentos-medicos' | 'gestao-carreira';
+
+type Track = {
+  id: TrackId;
+  title: string;
+  description: string;
+  badge?: string;
+};
+
+type Course = {
+  id: string;
+  title: string;
+  description: string;
+  category: TrackId;
+  level: string;
+  duration: string;
+  format: string;
+  badge?: string;
+  rating: number;
+  students: number;
+  nextClass: string;
+  investment: string;
+  highlights: string[];
+};
+
+const tracks = [
+  {
+    id: 'all',
+    title: 'Visão completa',
+    description: 'Combine trilhas para acelerar sua evolução financeira.'
+  },
+  {
+    id: 'financas-clinicas',
+    title: 'Finanças para clínicas',
+    description: 'Gestão de fluxo de caixa, precificação e indicadores.',
+    badge: 'Mais procurado'
+  },
+  {
+    id: 'investimentos-medicos',
+    title: 'Investimentos médicos',
+    description: 'Construção de patrimônio e proteção da renda.',
+    badge: 'Premium'
+  },
+  {
+    id: 'gestao-carreira',
+    title: 'Gestão de carreira',
+    description: 'Branding pessoal, posicionamento digital e agenda cheia.',
+    badge: 'Novo'
+  }
+] satisfies Track[];
+
+const courses = [
+  {
+    id: 'financial-strategy',
+    title: 'Estratégias financeiras para clínicas e consultórios',
+    description:
+      'Organize o fluxo de caixa, monitore indicadores essenciais e desenvolva planos de crescimento sustentáveis.',
+    category: 'financas-clinicas',
+    level: 'Intermediário',
+    duration: '6 semanas · 24h',
+    format: 'Ao vivo + laboratório prático',
+    badge: 'Mais procurado',
+    rating: 4.9,
+    students: 482,
+    nextClass: 'Novembro/2024',
+    investment: '12x de R$ 189',
+    highlights: ['Mentorias quinzenais com CFO convidado', 'Planilhas prontas para clínicas', 'Painel de indicadores no Notion']
+  },
+  {
+    id: 'tax-planning',
+    title: 'Planejamento tributário para profissionais da saúde',
+    description:
+      'Escolha o regime ideal, reduza a carga tributária legalmente e garanta conformidade fiscal sem surpresas.',
+    category: 'financas-clinicas',
+    level: 'Avançado',
+    duration: '4 semanas · 16h',
+    format: 'On-demand + sessões ao vivo',
+    rating: 4.8,
+    students: 291,
+    nextClass: 'Janeiro/2025',
+    investment: '10x de R$ 149',
+    highlights: ['Simulador tributário exclusivo', 'Checklist fiscal atualizado', 'Suporte com time contábil parceiro']
+  },
+  {
+    id: 'wealth-protection',
+    title: 'Investimentos e proteção de patrimônio médico',
+    description:
+      'Construa portfólio global, diversifique renda passiva e aprenda estratégias de blindagem patrimonial.',
+    category: 'investimentos-medicos',
+    level: 'Intermediário',
+    duration: '8 semanas · 32h',
+    format: 'Ao vivo + comunidade fechada',
+    badge: 'Certificação incluída',
+    rating: 5,
+    students: 358,
+    nextClass: 'Dezembro/2024',
+    investment: '12x de R$ 249',
+    highlights: ['Carteira modelo atualizada mensalmente', 'Aulas com especialistas convidados', 'Análise personalizada de riscos']
+  },
+  {
+    id: 'career-labs',
+    title: 'Growth e posicionamento para carreira médica',
+    description:
+      'Construa autoridade digital, otimize agenda de atendimentos e transforme pacientes em promotores da marca.',
+    category: 'gestao-carreira',
+    level: 'Intermediário',
+    duration: '5 semanas · 20h',
+    format: 'Híbrido · estudos de caso reais',
+    rating: 4.7,
+    students: 214,
+    nextClass: 'Fevereiro/2025',
+    investment: '12x de R$ 169',
+    highlights: ['Laboratório de conteúdo semanal', 'Diagnóstico de presença digital', 'Kit de playbooks prontos para ação']
+  },
+  {
+    id: 'financial-foundations',
+    title: 'Fundamentos de finanças pessoais para residentes',
+    description:
+      'Construa hábitos financeiros sólidos desde o início da carreira com métodos ágeis e práticos.',
+    category: 'investimentos-medicos',
+    level: 'Iniciante',
+    duration: '3 semanas · 12h',
+    format: 'On-demand + desafios guiados',
+    rating: 4.95,
+    students: 624,
+    nextClass: 'Turmas contínuas',
+    investment: '6x de R$ 79',
+    highlights: ['Trilha guiada de 21 dias', 'Templates de controle mensal', 'Feedback assíncrono do time']
+  }
+] satisfies Course[];
+
+const benefits = [
+  {
+    icon: '🎯',
+    title: 'Trilhas orientadas a resultados',
+    description:
+      'Cada curso termina com um plano de ação validado por especialistas para implementação imediata.'
+  },
+  {
+    icon: '🤝',
+    title: 'Comunidade de mentores',
+    description: 'Encontros quinzenais e networking com profissionais que lideram operações de saúde pelo Brasil.'
+  },
+  {
+    icon: '📊',
+    title: 'Ferramentas exclusivas',
+    description: 'Dashboards financeiros, calculadoras e modelos prontos para acelerar a tomada de decisão.'
+  }
+] as const;
+
+const journey = [
+  {
+    step: '1. Imersão ao vivo',
+    description: 'Aulas síncronas com especialistas e estudos de caso de clínicas reais.'
+  },
+  {
+    step: '2. Laboratórios guiados',
+    description: 'Aplicação prática com feedback individual do time MedFinance.'
+  },
+  {
+    step: '3. Implementação assistida',
+    description: 'Mentorias e acompanhamentos pós-curso para garantir resultados sustentáveis.'
+  }
+] as const;
+
+const faqs = [
+  {
+    question: 'Os cursos possuem certificado reconhecido?',
+    answer:
+      'Sim. Todos os cursos oferecem certificado digital validado pela MedFinance e aceito em programas de educação continuada.'
+  },
+  {
+    question: 'Como funcionam as mentorias ao vivo?',
+    answer:
+      'As mentorias acontecem em grupos reduzidos a cada quinze dias, com espaço para discutir indicadores, dúvidas fiscais e estratégias personalizadas.'
+  },
+  {
+    question: 'Consigo acessar os materiais após o término?',
+    answer:
+      'O acesso às aulas gravadas, planilhas e atualizações permanece disponível por 12 meses após a conclusão da turma.'
+  }
+] as const;
+
+const CoursesPage = () => {
+  const [selectedTrack, setSelectedTrack] = useState<TrackId>('all');
+
+  const filteredCourses = useMemo(() => {
+    if (selectedTrack === 'all') {
+      return courses;
+    }
+
+    return courses.filter((course) => course.category === selectedTrack);
+  }, [selectedTrack]);
+
+  return (
+    <div className="courses-page">
+      <header className="courses-hero">
+        <div className="container courses-hero__container">
+          <div className="courses-hero__content">
+            <span className="courses-hero__badge">Nova temporada 2024/2025</span>
+            <h1>Cursos MedFinance</h1>
+            <p>
+              Transforme sua relação com finanças, investimentos e gestão de carreira médica com programas intensivos
+              conduzidos por especialistas de mercado.
+            </p>
+            <div className="courses-hero__actions">
+              <a className="courses-hero__cta" href="#cursos">
+                Ver trilhas disponíveis
+              </a>
+              <a className="courses-hero__ghost" href="#mentorias">
+                Falar com um especialista
+              </a>
+            </div>
+            <dl className="courses-hero__stats">
+              <div>
+                <dt>+4.500</dt>
+                <dd>profissionais formados</dd>
+              </div>
+              <div>
+                <dt>96%</dt>
+                <dd>aplicação em até 60 dias</dd>
+              </div>
+              <div>
+                <dt>9.6/10</dt>
+                <dd>satisfação média das turmas</dd>
+              </div>
+            </dl>
+          </div>
+          <aside className="courses-hero__highlight" aria-label="Destaque dos cursos">
+            <h2>Experiência imersiva</h2>
+            <ul>
+              <li>
+                <strong>Agenda adaptada</strong>
+                <span>Encontros noturnos e gravações disponíveis no dia seguinte.</span>
+              </li>
+              <li>
+                <strong>Material premium</strong>
+                <span>Planilhas, templates de contratos e calculadoras financeiras prontas.</span>
+              </li>
+              <li>
+                <strong>Suporte dedicado</strong>
+                <span>Equipe multiespecialista acompanhando sua evolução semanal.</span>
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </header>
+
+      <section className="courses-tracks" aria-label="Trilhas de especialização">
+        <div className="container">
+          <div className="courses-tracks__intro">
+            <h2>Escolha a trilha que combina com sua fase</h2>
+            <p>
+              Alterne entre as trilhas para visualizar cursos, formatos e diferenciais pensados para desafios específicos
+              da carreira médica.
+            </p>
+          </div>
+          <div className="courses-tracks__options" role="tablist">
+            {tracks.map((track) => {
+              const isActive = selectedTrack === track.id;
+
+              return (
+                <button
+                  key={track.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  aria-controls="cursos"
+                  className={`courses-tracks__option${isActive ? ' courses-tracks__option--active' : ''}`}
+                  onClick={() => setSelectedTrack(track.id)}
+                >
+                  {track.badge ? <span className="courses-tracks__badge">{track.badge}</span> : null}
+                  <span className="courses-tracks__title">{track.title}</span>
+                  <span className="courses-tracks__description">{track.description}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="cursos"
+        className="courses-list"
+        aria-live="polite"
+        aria-labelledby="courses-list-heading"
+      >
+        <div className="container">
+          <div className="courses-list__header">
+            <h2 id="courses-list-heading">Cursos em destaque</h2>
+            <p>
+              {selectedTrack === 'all'
+                ? 'Veja os programas mais procurados para acelerar seus resultados financeiros.'
+                : 'Explore os cursos selecionados para essa trilha e descubra o próximo passo da sua evolução.'}
+            </p>
+          </div>
+          <div className="courses-list__grid">
+            {filteredCourses.map((course) => {
+              const titleId = `${course.id}-title`;
+
+              return (
+                <article key={course.id} className="course-card" aria-labelledby={titleId}>
+                  {course.badge ? <span className="course-card__badge">{course.badge}</span> : null}
+                  <header className="course-card__header">
+                    <h3 id={titleId}>{course.title}</h3>
+                    <p>{course.description}</p>
+                  </header>
+                  <dl className="course-card__meta">
+                    <div>
+                      <dt>Nível</dt>
+                      <dd>{course.level}</dd>
+                    </div>
+                    <div>
+                      <dt>Duração</dt>
+                      <dd>{course.duration}</dd>
+                    </div>
+                    <div>
+                      <dt>Formato</dt>
+                      <dd>{course.format}</dd>
+                    </div>
+                  </dl>
+                  <ul className="course-card__highlights">
+                    {course.highlights.map((highlight) => (
+                      <li key={highlight}>{highlight}</li>
+                    ))}
+                  </ul>
+                  <div className="course-card__stats" aria-label="Avaliação do curso">
+                    <span>
+                      {course.rating.toFixed(1)} ★ · {numberFormatter.format(course.students)} alunos
+                    </span>
+                  </div>
+                  <footer className="course-card__footer">
+                    <div>
+                      <span>Próxima turma</span>
+                      <strong>{course.nextClass}</strong>
+                    </div>
+                    <div>
+                      <span>Investimento</span>
+                      <strong>{course.investment}</strong>
+                    </div>
+                    <a className="course-card__cta" href="#mentorias">
+                      Ver detalhes
+                    </a>
+                  </footer>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="courses-benefits" aria-labelledby="benefits-heading">
+        <div className="container">
+          <header className="courses-benefits__header">
+            <h2 id="benefits-heading">O que torna a experiência MedFinance única?</h2>
+            <p>Uma jornada desenhada para médicos, gestores de clínica e equipes que buscam escala sustentável.</p>
+          </header>
+          <div className="courses-benefits__grid">
+            {benefits.map((benefit) => (
+              <article key={benefit.title} className="benefit-card">
+                <span className="benefit-card__icon" role="img" aria-hidden="true">
+                  {benefit.icon}
+                </span>
+                <h3>{benefit.title}</h3>
+                <p>{benefit.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="mentorias" className="courses-journey" aria-labelledby="journey-heading">
+        <div className="container">
+          <header className="courses-journey__header">
+            <h2 id="journey-heading">Sua jornada de transformação</h2>
+            <p>
+              Mais do que aulas, você recebe acompanhamento contínuo para implementar estratégias financeiras com confiança.
+            </p>
+          </header>
+          <ol className="courses-journey__timeline">
+            {journey.map((item) => (
+              <li key={item.step}>
+                <h3>{item.step}</h3>
+                <p>{item.description}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className="courses-faq" aria-labelledby="faq-heading">
+        <div className="container">
+          <header className="courses-faq__header">
+            <h2 id="faq-heading">Perguntas frequentes</h2>
+            <p>Transparência total para você decidir com tranquilidade.</p>
+          </header>
+          <dl className="courses-faq__list">
+            {faqs.map((faq) => (
+              <div key={faq.question}>
+                <dt>{faq.question}</dt>
+                <dd>{faq.answer}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default CoursesPage;

--- a/frontend-web/src/styles.css
+++ b/frontend-web/src/styles.css
@@ -443,4 +443,569 @@
     font-weight: 600;
     color: rgb(var(--color-gray-900) / 1);
   }
+
+  .courses-page {
+    display: flex;
+    flex-direction: column;
+    gap: 6rem;
+    background: linear-gradient(180deg, rgba(226, 232, 240, 0.6) 0%, rgba(255, 255, 255, 1) 30%);
+  }
+
+  .courses-hero {
+    background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.2), transparent 45%),
+      rgb(var(--color-gray-900) / 1);
+    color: white;
+    padding: 6rem 0 5rem;
+  }
+
+  .courses-hero__container {
+    display: grid;
+    gap: 3rem;
+  }
+
+  @media (min-width: 1024px) {
+    .courses-hero__container {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: center;
+    }
+  }
+
+  .courses-hero__content {
+    display: grid;
+    gap: 1.75rem;
+  }
+
+  .courses-hero__content h1 {
+    font-size: clamp(2.8rem, 4.2vw, 4rem);
+    margin: 0;
+  }
+
+  .courses-hero__content p {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.7;
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  .courses-hero__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    background: rgba(59, 130, 246, 0.18);
+    border: 1px solid rgba(147, 197, 253, 0.4);
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+  }
+
+  .courses-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .courses-hero__cta,
+  .courses-hero__ghost {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.75rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out);
+  }
+
+  .courses-hero__cta {
+    background: white;
+    color: rgb(var(--color-gray-900) / 1);
+    box-shadow: 0 18px 32px rgba(148, 197, 253, 0.35);
+  }
+
+  .courses-hero__cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 36px rgba(148, 197, 253, 0.4);
+  }
+
+  .courses-hero__ghost {
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .courses-hero__ghost:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.14);
+  }
+
+  .courses-hero__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .courses-hero__stats dt {
+    font-size: clamp(1.7rem, 2.6vw, 2.1rem);
+    margin: 0;
+  }
+
+  .courses-hero__stats dd {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  .courses-hero__highlight {
+    background: rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(148, 197, 253, 0.2);
+    border-radius: var(--radius-2xl);
+    padding: 2rem;
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .courses-hero__highlight h2 {
+    margin: 0;
+    font-size: clamp(1.6rem, 2.2vw, 1.9rem);
+  }
+
+  .courses-hero__highlight ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 1.25rem;
+  }
+
+  .courses-hero__highlight li {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .courses-hero__highlight strong {
+    font-size: 1.05rem;
+  }
+
+  .courses-hero__highlight span {
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.6;
+  }
+
+  .courses-tracks {
+    padding: 5rem 0;
+  }
+
+  .courses-tracks__intro {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto 3rem;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .courses-tracks__intro h2 {
+    margin: 0;
+    font-size: clamp(2rem, 3vw, 2.5rem);
+  }
+
+  .courses-tracks__intro p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.7;
+  }
+
+  .courses-tracks__options {
+    display: grid;
+    gap: 1rem;
+  }
+
+  @media (min-width: 900px) {
+    .courses-tracks__options {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+
+  .courses-tracks__option {
+    display: grid;
+    gap: 0.75rem;
+    align-content: start;
+    background: white;
+    border-radius: var(--radius-xl);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 1.75rem 1.5rem;
+    text-align: left;
+    transition: border-color 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out), transform 0.2s var(--ease-out);
+    cursor: pointer;
+  }
+
+  .courses-tracks__option:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  }
+
+  .courses-tracks__option--active {
+    border-color: rgba(37, 99, 235, 0.6);
+    box-shadow: 0 18px 36px rgba(37, 99, 235, 0.15);
+  }
+
+  .courses-tracks__badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgb(var(--color-brand-700) / 1);
+    background: rgba(191, 219, 254, 0.6);
+    border-radius: 999px;
+    padding: 0.3rem 0.75rem;
+    width: fit-content;
+  }
+
+  .courses-tracks__title {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: rgb(var(--color-gray-900) / 1);
+  }
+
+  .courses-tracks__description {
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.6;
+  }
+
+  .courses-list {
+    padding: 5rem 0;
+    background: linear-gradient(180deg, rgba(37, 99, 235, 0.05) 0%, rgba(255, 255, 255, 1) 60%);
+  }
+
+  .courses-list__header {
+    max-width: 720px;
+    margin: 0 auto 3rem;
+    text-align: center;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .courses-list__header h2 {
+    margin: 0;
+    font-size: clamp(2rem, 3vw, 2.5rem);
+  }
+
+  .courses-list__header p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.7;
+  }
+
+  .courses-list__grid {
+    display: grid;
+    gap: 1.75rem;
+  }
+
+  @media (min-width: 1024px) {
+    .courses-list__grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .course-card {
+    position: relative;
+    display: grid;
+    gap: 1.5rem;
+    background: white;
+    border-radius: var(--radius-2xl);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 2rem;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  }
+
+  .course-card__badge {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.15);
+    color: rgb(var(--color-brand-700) / 1);
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .course-card__header {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .course-card__header h3 {
+    margin: 0;
+    font-size: clamp(1.4rem, 2vw, 1.7rem);
+  }
+
+  .course-card__header p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.7;
+  }
+
+  .course-card__meta {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .course-card__meta div {
+    display: grid;
+    gap: 0.3rem;
+  }
+
+  .course-card__meta dt {
+    margin: 0;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgb(var(--color-gray-500) / 1);
+  }
+
+  .course-card__meta dd {
+    margin: 0;
+    font-weight: 600;
+    color: rgb(var(--color-gray-900) / 1);
+  }
+
+  .course-card__highlights {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .course-card__highlights li {
+    position: relative;
+    padding-left: 1.5rem;
+    color: rgb(var(--color-gray-600) / 1);
+  }
+
+  .course-card__highlights li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.5rem;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: rgb(var(--color-brand-500) / 1);
+  }
+
+  .course-card__stats span {
+    font-weight: 600;
+    color: rgb(var(--color-gray-700) / 1);
+  }
+
+  .course-card__footer {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    align-items: end;
+  }
+
+  .course-card__footer span {
+    display: block;
+    font-size: 0.85rem;
+    color: rgb(var(--color-gray-500) / 1);
+  }
+
+  .course-card__footer strong {
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 1.1rem;
+    color: rgb(var(--color-gray-900) / 1);
+  }
+
+  .course-card__cta {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0.75rem 1.25rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    background: rgb(var(--color-gray-900) / 1);
+    color: white;
+    transition: transform 0.2s var(--ease-out), box-shadow 0.2s var(--ease-out);
+  }
+
+  .course-card__cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.2);
+  }
+
+  .courses-benefits {
+    padding: 5rem 0;
+  }
+
+  .courses-benefits__header {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto 3rem;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .courses-benefits__header h2 {
+    margin: 0;
+    font-size: clamp(2rem, 3vw, 2.5rem);
+  }
+
+  .courses-benefits__header p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.7;
+  }
+
+  .courses-benefits__grid {
+    display: grid;
+    gap: 1.75rem;
+  }
+
+  @media (min-width: 900px) {
+    .courses-benefits__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .benefit-card {
+    background: white;
+    border-radius: var(--radius-2xl);
+    padding: 2rem;
+    box-shadow: 0 22px 44px rgba(15, 23, 42, 0.1);
+    display: grid;
+    gap: 1rem;
+    text-align: left;
+  }
+
+  .benefit-card__icon {
+    font-size: 2rem;
+  }
+
+  .benefit-card h3 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+
+  .benefit-card p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.6;
+  }
+
+  .courses-journey {
+    padding: 5rem 0;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(15, 23, 42, 0.85) 100%);
+    color: white;
+  }
+
+  .courses-journey__header {
+    text-align: center;
+    max-width: 680px;
+    margin: 0 auto 3rem;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .courses-journey__header h2 {
+    margin: 0;
+    font-size: clamp(2rem, 3vw, 2.6rem);
+  }
+
+  .courses-journey__header p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.7;
+  }
+
+  .courses-journey__timeline {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 900px) {
+    .courses-journey__timeline {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .courses-journey__timeline li {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(148, 197, 253, 0.2);
+    border-radius: var(--radius-2xl);
+    padding: 2rem;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .courses-journey__timeline h3 {
+    margin: 0;
+    font-size: 1.2rem;
+  }
+
+  .courses-journey__timeline p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.6;
+  }
+
+  .courses-faq {
+    padding: 5rem 0 6rem;
+  }
+
+  .courses-faq__header {
+    text-align: center;
+    max-width: 680px;
+    margin: 0 auto 3rem;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .courses-faq__header h2 {
+    margin: 0;
+    font-size: clamp(2rem, 3vw, 2.5rem);
+  }
+
+  .courses-faq__header p {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+  }
+
+  .courses-faq__list {
+    display: grid;
+    gap: 1.5rem;
+    background: white;
+    border-radius: var(--radius-2xl);
+    padding: 2.5rem;
+    box-shadow: 0 22px 44px rgba(15, 23, 42, 0.1);
+  }
+
+  .courses-faq__list div {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .courses-faq__list dt {
+    margin: 0;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: rgb(var(--color-gray-900) / 1);
+  }
+
+  .courses-faq__list dd {
+    margin: 0;
+    color: rgb(var(--color-gray-600) / 1);
+    line-height: 1.7;
+  }
 }


### PR DESCRIPTION
## Summary
- add a dedicated CoursesPage with hero, track filters, featured courses, benefits, journey, and FAQ sections
- update the app entry point and styling tokens to render the modern courses experience
- refresh unit tests to cover the new courses layout and filtering behaviour

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3c2b9838883228dc2884c1148300e