### PR TITLE
Resolve conflicts for workspace tooling updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ mobile/node_modules/
 
 dist/
 backend/build/
+backend/dist/
 frontend-web/dist/
 cli/dist/
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "test": "npm run test --workspaces --if-present",
     "build": "npm run build --workspace backend && npm run build --workspace frontend-web",
     "dev": "echo 'Execute os servidores individuais com npm run dev em cada workspace.'",
+    "dev:backend": "npm run dev --workspace backend",
+    "dev:frontend-web": "npm run dev --workspace frontend-web",
+    "dev:frontend-mobile": "npm run start --workspace frontend-mobile",
+    "dev:cli": "npm run dev --workspace cli",
+    "start:backend": "npm run start --workspace backend",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
     "ci": "npm run test && npm run build"


### PR DESCRIPTION
## Summary
- add the backend TypeScript build output to the repository gitignore so dist artifacts stay untracked after builds
- expose helper npm scripts for running backend, web, mobile, and CLI workspaces directly from the monorepo root

## Testing
- npm run test --workspace backend *(fails: "Preset ts-jest not found.")*

------
https://chatgpt.com/codex/tasks/task_e_68e3c6711dc88322a2f46f2c874f5d43