### PR TITLE
Restrict video uploads to administrators

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import swaggerUi from 'swagger-ui-express';
 import { requestLogger } from './middlewares/requestLogger';
 import { router as userRouter } from './routes/users';
 import { router as investmentRouter } from './routes/investments';
+import { router as videoRouter } from './routes/videos';
 
 export function createApp() {
   const app = express();
@@ -54,6 +55,7 @@ export function createApp() {
 
   app.use('/users', userRouter);
   app.use('/investments', investmentRouter);
+  app.use('/videos', videoRouter);
 
   app.use((req, res) => {
     const message = `Route ${req.method} ${req.path} not found`;

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -27,6 +27,10 @@ export const swaggerDocument = {
       name: 'Investments',
       description: 'Endpoints that provide investment-related information.',
     },
+    {
+      name: 'Videos',
+      description: 'Endpoints responsible for managing educational video content.',
+    },
   ],
   paths: {
     '/healthcheck': {
@@ -188,12 +192,155 @@ export const swaggerDocument = {
         },
       },
     },
+    '/videos': {
+      get: {
+        tags: ['Videos'],
+        summary: 'Lists all uploaded educational videos.',
+        description:
+          'Retrieves the catalog of educational videos available within the MedFinance learning platform.',
+        responses: {
+          '200': {
+            description: 'Collection of uploaded videos.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['videos'],
+                  properties: {
+                    videos: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Video' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/videos/upload': {
+      post: {
+        tags: ['Videos'],
+        summary: 'Uploads a new educational video.',
+        description:
+          'Allows administrators to upload new video lessons. The request must be authenticated using the "x-user-id" header.',
+        parameters: [
+          {
+            in: 'header',
+            name: 'x-user-id',
+            description: 'Identifier of the authenticated user performing the operation.',
+            required: true,
+            schema: {
+              type: 'string',
+              example: '1',
+            },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/VideoUploadInput',
+              },
+            },
+          },
+        },
+        responses: {
+          '201': {
+            description: 'Video uploaded successfully.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['video'],
+                  properties: {
+                    video: {
+                      $ref: '#/components/schemas/Video',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Validation error for the provided payload.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['message'],
+                  properties: {
+                    message: {
+                      type: 'string',
+                      example: 'The "title" field is required.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Missing authentication header.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['message'],
+                  properties: {
+                    message: {
+                      type: 'string',
+                      example: 'The "x-user-id" header is required to authenticate the request.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '403': {
+            description: 'User is authenticated but does not have permission to upload videos.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['message'],
+                  properties: {
+                    message: {
+                      type: 'string',
+                      example: 'Video upload is restricted to administrator profiles.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '404': {
+            description: 'Authenticated user could not be found.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['message'],
+                  properties: {
+                    message: {
+                      type: 'string',
+                      example: 'User not found.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   components: {
     schemas: {
       User: {
         type: 'object',
-        required: ['id', 'name', 'email', 'role'],
+        required: ['id', 'name', 'email', 'role', 'permissions'],
         properties: {
           id: {
             type: 'string',
@@ -216,6 +363,76 @@ export const swaggerDocument = {
             description: "User's role inside the platform.",
             enum: ['admin', 'student'],
             example: 'admin',
+          },
+          permissions: {
+            type: 'array',
+            description: 'Capabilities granted to the user within the platform.',
+            items: {
+              type: 'string',
+              enum: ['manage_videos', 'manage_courses', 'manage_users', 'view_courses'],
+            },
+            example: ['manage_videos', 'manage_courses', 'manage_users', 'view_courses'],
+          },
+        },
+      },
+      VideoUploadInput: {
+        type: 'object',
+        required: ['title', 'url'],
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Title presented to students when browsing the catalog.',
+            example: 'Introdução à gestão financeira para clínicas médicas',
+          },
+          description: {
+            type: 'string',
+            description: 'Optional description outlining the main topics covered in the video.',
+            example: 'Guia completo para montar indicadores e projeções de fluxo de caixa.',
+          },
+          url: {
+            type: 'string',
+            format: 'uri',
+            description: 'URL pointing to the hosted video asset.',
+            example: 'https://cdn.medfinance.com/videos/gestao-financeira.mp4',
+          },
+        },
+      },
+      Video: {
+        type: 'object',
+        required: ['id', 'title', 'url', 'uploadedBy', 'uploadedAt'],
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Unique identifier of the uploaded video.',
+            example: '0f95ec88-0b3f-4677-b9df-3a6d3f640efd',
+          },
+          title: {
+            type: 'string',
+            description: 'Video title.',
+            example: 'Introdução à gestão financeira para clínicas médicas',
+          },
+          description: {
+            type: 'string',
+            nullable: true,
+            description: 'Optional description of the video content.',
+            example: 'Guia completo para montar indicadores e projeções de fluxo de caixa.',
+          },
+          url: {
+            type: 'string',
+            format: 'uri',
+            description: 'Location where the video is hosted.',
+            example: 'https://cdn.medfinance.com/videos/gestao-financeira.mp4',
+          },
+          uploadedBy: {
+            type: 'string',
+            description: 'Identifier of the administrator who uploaded the video.',
+            example: '1',
+          },
+          uploadedAt: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Timestamp indicating when the video was uploaded.',
+            example: '2024-04-03T18:02:15.000Z',
           },
         },
       },

--- a/backend/src/middlewares/requireAdmin.ts
+++ b/backend/src/middlewares/requireAdmin.ts
@@ -1,0 +1,26 @@
+import type { NextFunction, Request, Response } from 'express';
+import { userService } from '../services/userService';
+
+export function requireAdmin(req: Request, res: Response, next: NextFunction) {
+  const userId = req.header('x-user-id');
+
+  if (!userId) {
+    res.status(401).json({ message: 'The "x-user-id" header is required to authenticate the request.' });
+    return;
+  }
+
+  const user = userService.findById(userId);
+
+  if (!user) {
+    res.status(404).json({ message: 'User not found.' });
+    return;
+  }
+
+  if (user.role !== 'admin') {
+    res.status(403).json({ message: 'Video upload is restricted to administrator profiles.' });
+    return;
+  }
+
+  res.locals.authenticatedUser = user;
+  next();
+}

--- a/backend/src/routes/videos.ts
+++ b/backend/src/routes/videos.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { requireAdmin } from '../middlewares/requireAdmin';
+import type { User } from '../services/userService';
+import { videoService } from '../services/videoService';
+
+export const router = Router();
+
+router.get('/', (_req, res) => {
+  const videos = videoService.list();
+
+  res.json({ videos });
+});
+
+router.post('/upload', requireAdmin, (req, res) => {
+  const { title, description, url } = req.body ?? {};
+
+  if (typeof title !== 'string' || title.trim() === '') {
+    res.status(400).json({ message: 'The "title" field is required.' });
+    return;
+  }
+
+  if (typeof url !== 'string' || url.trim() === '') {
+    res.status(400).json({ message: 'The "url" field is required.' });
+    return;
+  }
+
+  const authenticatedUser = res.locals.authenticatedUser as User;
+
+  const video = videoService.create({
+    title: title.trim(),
+    description: typeof description === 'string' && description.trim() !== '' ? description.trim() : undefined,
+    url: url.trim(),
+    uploadedBy: authenticatedUser.id,
+  });
+
+  res.status(201).json({ video });
+});

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -1,18 +1,43 @@
+export type UserRole = 'admin' | 'student';
+
+export type UserPermission =
+  | 'manage_videos'
+  | 'manage_courses'
+  | 'manage_users'
+  | 'view_courses';
+
 export type User = {
   id: string;
   name: string;
   email: string;
-  role: 'admin' | 'student';
+  role: UserRole;
+  permissions: UserPermission[];
 };
 
 const users: User[] = [
-  { id: '1', name: 'Dra. Ana Souza', email: 'ana.souza@example.com', role: 'admin' },
-  { id: '2', name: 'Dr. Bruno Lima', email: 'bruno.lima@example.com', role: 'student' },
+  {
+    id: '1',
+    name: 'Dra. Ana Souza',
+    email: 'ana.souza@example.com',
+    role: 'admin',
+    permissions: ['manage_videos', 'manage_courses', 'manage_users', 'view_courses'],
+  },
+  {
+    id: '2',
+    name: 'Dr. Bruno Lima',
+    email: 'bruno.lima@example.com',
+    role: 'student',
+    permissions: ['view_courses'],
+  },
 ];
 
 export class UserService {
   list(): User[] {
     return users;
+  }
+
+  findById(id: string): User | undefined {
+    return users.find((user) => user.id === id);
   }
 }
 

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from 'crypto';
+import type { User } from './userService';
+
+type CreateVideoInput = {
+  title: string;
+  description?: string;
+  url: string;
+  uploadedBy: User['id'];
+};
+
+export type Video = CreateVideoInput & {
+  id: string;
+  uploadedAt: string;
+};
+
+class VideoService {
+  private videos: Video[] = [];
+
+  list(): Video[] {
+    return this.videos;
+  }
+
+  create(input: CreateVideoInput): Video {
+    const video: Video = {
+      id: randomUUID(),
+      title: input.title,
+      description: input.description,
+      url: input.url,
+      uploadedBy: input.uploadedBy,
+      uploadedAt: new Date().toISOString(),
+    };
+
+    this.videos = [video, ...this.videos];
+
+    return video;
+  }
+
+  clear(): void {
+    this.videos = [];
+  }
+}
+
+export const videoService = new VideoService();

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,7 @@
+import type { User } from '../services/userService';
+
+declare module 'express-serve-static-core' {
+  interface ResponseLocals {
+    authenticatedUser?: User;
+  }
+}

--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -68,6 +68,8 @@ describe('MedFinance API', () => {
         '/users': expect.any(Object),
         '/healthcheck': expect.any(Object),
         '/investments/cdi': expect.any(Object),
+        '/videos': expect.any(Object),
+        '/videos/upload': expect.any(Object),
       }),
     });
   });

--- a/backend/tests/videos.test.ts
+++ b/backend/tests/videos.test.ts
@@ -1,0 +1,94 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+import { videoService } from '../src/services/videoService';
+import { userService } from '../src/services/userService';
+
+const app = createApp();
+const [adminUser, studentUser] = userService.list();
+
+describe('Video upload access control', () => {
+  beforeEach(() => {
+    videoService.clear();
+  });
+
+  it('rejects uploads without authentication header', async () => {
+    const response = await request(app).post('/videos/upload').send({
+      title: 'Educação Financeira',
+      url: 'https://cdn.medfinance.com/videos/educacao-financeira.mp4',
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      message: 'The "x-user-id" header is required to authenticate the request.',
+    });
+  });
+
+  it('rejects uploads for unknown users', async () => {
+    const response = await request(app)
+      .post('/videos/upload')
+      .set('x-user-id', '999')
+      .send({
+        title: 'Educação Financeira',
+        url: 'https://cdn.medfinance.com/videos/educacao-financeira.mp4',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'User not found.' });
+  });
+
+  it('blocks students from uploading videos', async () => {
+    const response = await request(app)
+      .post('/videos/upload')
+      .set('x-user-id', studentUser.id)
+      .send({
+        title: 'Planejamento tributário',
+        url: 'https://cdn.medfinance.com/videos/planejamento-tributario.mp4',
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ message: 'Video upload is restricted to administrator profiles.' });
+  });
+
+  it('validates required payload fields', async () => {
+    const response = await request(app)
+      .post('/videos/upload')
+      .set('x-user-id', adminUser.id)
+      .send({ description: 'Material sem título ou URL' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ message: 'The "title" field is required.' });
+  });
+
+  it('allows administrators to upload videos and list them', async () => {
+    const payload = {
+      title: 'Gestão de clínicas de alta performance',
+      description: 'Estratégias para estruturar processos financeiros e operacionais.',
+      url: 'https://cdn.medfinance.com/videos/gestao-clinicas.mp4',
+    };
+
+    const uploadResponse = await request(app)
+      .post('/videos/upload')
+      .set('x-user-id', adminUser.id)
+      .send(payload);
+
+    expect(uploadResponse.status).toBe(201);
+    expect(uploadResponse.body.video).toEqual(
+      expect.objectContaining({
+        title: payload.title,
+        description: payload.description,
+        url: payload.url,
+        uploadedBy: adminUser.id,
+      })
+    );
+
+    const listResponse = await request(app).get('/videos');
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.videos[0]).toMatchObject({
+      title: payload.title,
+      description: payload.description,
+      url: payload.url,
+      uploadedBy: adminUser.id,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an in-memory video catalog with routes, service, and middleware that require administrator authentication to upload content
- extend the user model with explicit permissions and document the new video endpoints in the OpenAPI spec
- cover the new access controls with backend integration tests and update existing API documentation checks

## Testing
- npm test -- --runInBand (backend)


------
https://chatgpt.com/codex/tasks/task_e_68e3ca87a6588322b38a757989a992ef